### PR TITLE
Paramterize Client on Key Provider

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ mod token;
 
 pub use client::Client;
 pub use token::{Token, IdPayload, RequiredClaims};
-
+pub use key_provider::{KeyProvider,GoogleKeyProvider};
 
 fn base64_decode(input: &str) -> Result<Vec<u8>, base64::DecodeError> {
     base64::decode_config(&input, base64::URL_SAFE)

--- a/src/test.rs
+++ b/src/test.rs
@@ -44,16 +44,14 @@ pub fn decode_keys() {
 
 #[test]
 pub fn test_client() {
-    let client = Client::builder("37772117408-qjqo9hca513pdcunumt7gk08ii6te8is.apps.googleusercontent.com")
-        .custom_key_provider(TestKeyProvider)
+    let client = Client::with_key_provder("37772117408-qjqo9hca513pdcunumt7gk08ii6te8is.apps.googleusercontent.com", TestKeyProvider)
         .build();
     assert_eq!(client.verify_token(TOKEN).map(|_| ()), Err(Error::Expired));
 }
 
 #[test]
 pub fn test_client_invalid_client_id() {
-    let client = Client::builder("invalid client id")
-        .custom_key_provider(TestKeyProvider)
+    let client = Client::with_key_provder("invalid client id", TestKeyProvider)
         .build();
     let result = client.verify_token(TOKEN).map(|_| ());
     assert_eq!(result, Err(Error::InvalidToken))
@@ -61,8 +59,7 @@ pub fn test_client_invalid_client_id() {
 
 #[test]
 pub fn test_id_token() {
-    let client = Client::builder(AUDIENCE)
-        .custom_key_provider(TestKeyProvider)
+    let client = Client::with_key_provder(AUDIENCE, TestKeyProvider)
         .unsafe_ignore_expiration()
         .build();
     let id_token = client.verify_id_token(TOKEN).expect("id token should be valid");


### PR DESCRIPTION
By parameterizing the `Client` on the `KeyProvider` we're able to avoid dynamic dispatch on the
`KeyProvider` (eg, it's no longer a trait object).

My real motivation here is that I want to be able to add Send to the KeyProvider
trait object in the client (as I need to send my client between threads), but I can't. Simply wrapping the client in an Arc does not solve the problem, the only
fix seems to be annotating the KeyProvider on the client with Send.

However, annotating the KeyProvider with send is more restrictive, and I think the underlying issue is
that we want to parameterize over the KeyProvider rather than use a trait object. This is more flexible
and allows the caller to dictate the bounds of the KeyProvider.

This change also makes public the KeyProvider and GoogleKeyProvider classes. This seems reasonable
to me, given that we already expose the ability to override the KeyProvider (without actually allowing users
to implement their own KeyProvider class, which seems odd, and I may be misunderstanding something).

This works and compiles and is probably good enough, but it introduces some breaking changes  around the `Client`, as we're adding a type parameter. Happy to discuss alternatives. 