### PR TITLE
Implement asynchronous token verification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ matrix:
 before_script:
   - rustup component add rustfmt
 script:
-  - cargo build
-  - cargo test
+  - cargo build --all-features
+  - cargo test --all-features
   - cargo fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,9 @@ A client to verify Google JSON web tokens
 edition = "2018"
 
 [features]
+default = ["blocking"]
 async = ["async-trait"]
+blocking = ["reqwest/blocking"]
 
 [dependencies]
 async-trait = {version = "0.1.42", optional = true}
@@ -20,7 +22,7 @@ base64 = "0.11.0"
 serde = "1.0.104"
 serde_json = "1.0.48"
 serde_derive = "1.0.104"
-reqwest = {version="0.10.4", features=["blocking"]}
+reqwest = {version="0.10.4"}
 headers = "0.3.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,11 @@ A client to verify Google JSON web tokens
 """
 edition = "2018"
 
+[features]
+async = ["async-trait"]
+
 [dependencies]
-async-trait = "0.1.42"
+async-trait = {version = "0.1.42", optional = true}
 openssl = "0.10.28"
 base64 = "0.11.0"
 serde = "1.0.104"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ A client to verify Google JSON web tokens
 edition = "2018"
 
 [dependencies]
+async-trait = "0.1.42"
 openssl = "0.10.28"
 base64 = "0.11.0"
 serde = "1.0.104"
@@ -18,3 +19,6 @@ serde_json = "1.0.48"
 serde_derive = "1.0.104"
 reqwest = {version="0.10.4", features=["blocking"]}
 headers = "0.3.1"
+
+[dev-dependencies]
+tokio = {version = "0.2", features = ["macros"]}

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,14 +1,10 @@
-use crate::{jwk::JsonWebKey, base64_decode};
+use crate::unverified_token::UnverifiedToken;
 use crate::error::Error;
 use crate::key_provider::{AsyncKeyProvider, GoogleKeyProvider, KeyProvider};
 use crate::token::IdPayload;
-use crate::token::RequiredClaims;
 use crate::token::Token;
-use serde::Deserialize as DeserializeTrait;
-use serde_derive::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::sync::{Arc, Mutex};
-use std::time::SystemTime;
-use std::time::UNIX_EPOCH;
 
 pub type Client = GenericClient<GoogleKeyProvider>;
 
@@ -67,7 +63,7 @@ impl<KP: Default> GenericClient<KP> {
 impl<KP: KeyProvider> GenericClient<KP> {
     pub fn verify_token_with_payload<P>(&self, token_string: &str) -> Result<Token<P>, Error>
     where
-        for<'a> P: DeserializeTrait<'a>,
+        for<'a> P: Deserialize<'a>,
     {
         let unverified_token = UnverifiedToken::<P>::validate(token_string, self.check_expiration, &self.client_id)?;
         unverified_token.verify(&self.key_provider)
@@ -85,7 +81,7 @@ impl<KP: KeyProvider> GenericClient<KP> {
 impl<KP: AsyncKeyProvider> GenericClient<KP> {
     pub async fn verify_token_with_payload_async<P>(&self, token_string: &str) -> Result<Token<P>, Error>
     where
-        for<'a> P: DeserializeTrait<'a>,
+        for<'a> P: Deserialize<'a>,
     {
         let unverified_token = UnverifiedToken::<P>::validate(token_string, self.check_expiration, &self.client_id)?;
         unverified_token.verify_async(&self.key_provider).await
@@ -98,81 +94,4 @@ impl<KP: AsyncKeyProvider> GenericClient<KP> {
     pub async fn verify_id_token_async(&self, token_string: &str) -> Result<Token<IdPayload>, Error> {
         self.verify_token_with_payload_async(token_string).await
     }
-}
-
-struct UnverifiedToken<P> {
-    header: Header,
-    signed_body: String,
-    signature: Vec<u8>,
-    claims: RequiredClaims,
-    json_payload: P
-}
-
-impl<P> UnverifiedToken<P>
-where
-    for<'a> P: DeserializeTrait<'a>
-{
-    fn validate(token_string: &str, check_expiration: bool, client_id: &str) -> Result<Self, Error> {
-        let mut segments = token_string.split('.');
-        let encoded_header = segments.next().ok_or(Error::InvalidToken)?;
-        let encoded_payload = segments.next().ok_or(Error::InvalidToken)?;
-        let encoded_signature = segments.next().ok_or(Error::InvalidToken)?;
-
-        let header: Header = serde_json::from_slice(&base64_decode(&encoded_header)?)?;
-        let signed_body = format!("{}.{}", encoded_header, encoded_payload);
-        let signature = base64_decode(&encoded_signature)?;
-        let payload = base64_decode(&encoded_payload)?;
-        let claims: RequiredClaims = serde_json::from_slice(&payload)?;
-        if claims.get_audience() != client_id {
-            return Err(Error::InvalidToken);
-        }
-        let issuer = claims.get_issuer();
-        if issuer != "https://accounts.google.com" && issuer != "accounts.google.com" {
-            return Err(Error::InvalidToken);
-        }
-        let current_timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-        if check_expiration && claims.get_expires_at() < current_timestamp {
-            return Err(Error::Expired);
-        }
-        if claims.get_issued_at() > claims.get_expires_at() {
-            return Err(Error::InvalidToken);
-        }
-        let json_payload: P = serde_json::from_slice(&payload)?;
-        Ok(Self {
-            claims,
-            signature,
-            signed_body,
-            json_payload,
-            header
-        })
-    }
-}
-
-impl<P> UnverifiedToken<P> {
-    pub fn verify<KP: KeyProvider>(self, key_provider: &Arc<Mutex<KP>>) -> Result<Token<P>, Error> {
-        let key_id = self.header.key_id.clone();
-        self.verify_with_key(key_provider.lock().unwrap().get_key(&key_id))
-    }
-    pub async fn verify_async<KP: AsyncKeyProvider>(self, key_provider: &Arc<Mutex<KP>>) ->  Result<Token<P>, Error> {
-        let key_id = self.header.key_id.clone();
-        self.verify_with_key(key_provider.lock().unwrap().get_key_async(&key_id).await)
-    }
-    fn verify_with_key(self, key: Result<Option<JsonWebKey>, ()>) -> Result<Token<P>, Error> {
-        let key = match key {
-            Ok(Some(key)) => key,
-            Ok(None) => return Err(Error::InvalidToken),
-            Err(_) => return Err(Error::RetrieveKeyFailure),
-        };
-        key.verify(self.signed_body.as_bytes(), &self.signature)?;
-        Ok(Token::new(self.claims, self.json_payload))
-    }
-}
-
-#[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Debug)]
-pub struct Header {
-    #[serde(rename = "kid")]
-    key_id: String,
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,4 @@
-use crate::base64_decode;
+use crate::{jwk::JsonWebKey, base64_decode};
 use crate::error::Error;
 use crate::key_provider::{AsyncKeyProvider, GoogleKeyProvider, KeyProvider};
 use crate::token::IdPayload;
@@ -10,41 +10,38 @@ use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
-pub struct ClientBuilder {
+pub type Client = GenericClient<GoogleKeyProvider>;
+
+pub struct GenericClientBuilder<KP> {
     client_id: String,
-    key_provider: Arc<Mutex<dyn KeyProvider + Send>>,
+    key_provider: Arc<Mutex<KP>>,
     check_expiration: bool,
 }
 
-pub struct AsyncClientBuilder {
-    client_id: String,
-    key_provider: Arc<Mutex<dyn AsyncKeyProvider + Send>>,
-    check_expiration: bool,
-}
-
-impl AsyncClientBuilder {
-    pub fn new(client_id: &str) -> AsyncClientBuilder {
-        AsyncClientBuilder {
+impl<KP: Default> GenericClientBuilder<KP> {
+    pub fn new(client_id: &str) -> GenericClientBuilder<KP> {
+        GenericClientBuilder::<KP> {
             client_id: client_id.to_owned(),
-            key_provider: Arc::new(Mutex::new(GoogleKeyProvider::new())),
+            key_provider: Arc::new(Mutex::new(KP::default())),
             check_expiration: true,
         }
     }
-    pub fn custom_key_provider<T: AsyncKeyProvider + Send + 'static>(
-        mut self,
-        provider: T,
-    ) -> Self {
-        self.key_provider = Arc::new(Mutex::new(provider));
-        self
-    }
+}
 
+impl<KP> GenericClientBuilder<KP> {
+    pub fn custom_key_provider<T>(self, provider: T) -> GenericClientBuilder<T> {
+        GenericClientBuilder {
+            client_id: self.client_id,
+            key_provider: Arc::new(Mutex::new(provider)),
+            check_expiration: self.check_expiration
+        }
+    }
     pub fn unsafe_ignore_expiration(mut self) -> Self {
         self.check_expiration = false;
         self
     }
-
-    pub fn build(self) -> AsyncClient {
-        AsyncClient {
+    pub fn build(self) -> GenericClient<KP> {
+        GenericClient {
             client_id: self.client_id,
             key_provider: self.key_provider,
             check_expiration: self.check_expiration,
@@ -52,162 +49,28 @@ impl AsyncClientBuilder {
     }
 }
 
-impl ClientBuilder {
-    pub fn new(client_id: &str) -> ClientBuilder {
-        ClientBuilder {
-            client_id: client_id.to_owned(),
-            key_provider: Arc::new(Mutex::new(GoogleKeyProvider::new())),
-            check_expiration: true,
-        }
-    }
-    pub fn custom_key_provider<T: KeyProvider + Send + 'static>(mut self, provider: T) -> Self {
-        self.key_provider = Arc::new(Mutex::new(provider));
-        self
-    }
-
-    pub fn unsafe_ignore_expiration(mut self) -> Self {
-        self.check_expiration = false;
-        self
-    }
-
-    pub fn build(self) -> Client {
-        Client {
-            client_id: self.client_id,
-            key_provider: self.key_provider,
-            check_expiration: self.check_expiration,
-        }
-    }
-}
-
-pub struct AsyncClient {
+pub struct GenericClient<T> {
     client_id: String,
-    key_provider: Arc<Mutex<dyn AsyncKeyProvider + Send>>,
+    key_provider: Arc<Mutex<T>>,
     check_expiration: bool,
 }
 
-impl AsyncClient {
-    pub fn builder(client_id: &str) -> AsyncClientBuilder {
-        AsyncClientBuilder::new(client_id)
+impl<KP: Default> GenericClient<KP> {
+    pub fn builder(client_id: &str) -> GenericClientBuilder<KP> {
+        GenericClientBuilder::<KP>::new(client_id)
     }
-
-    pub fn new(client_id: &str) -> AsyncClient {
-        AsyncClientBuilder::new(client_id).build()
-    }
-
-    pub async fn verify_token_with_payload<P>(&self, token_string: &str) -> Result<Token<P>, Error>
-    where
-        for<'a> P: DeserializeTrait<'a>,
-    {
-        let mut segments = token_string.split('.');
-        let encoded_header = segments.next().ok_or(Error::InvalidToken)?;
-        let encoded_payload = segments.next().ok_or(Error::InvalidToken)?;
-        let encoded_signature = segments.next().ok_or(Error::InvalidToken)?;
-
-        let header: Header = serde_json::from_slice(&base64_decode(&encoded_header)?)?;
-
-        let key = match self
-            .key_provider
-            .lock()
-            .unwrap()
-            .get_key_async(&header.key_id)
-            .await
-        {
-            Ok(Some(key)) => key,
-            Ok(None) => return Err(Error::InvalidToken),
-            Err(_) => return Err(Error::RetrieveKeyFailure),
-        };
-        let signed_body = format!("{}.{}", encoded_header, encoded_payload);
-        let signature = base64_decode(&encoded_signature)?;
-        key.verify(signed_body.as_bytes(), &signature)?;
-        let payload = base64_decode(&encoded_payload)?;
-        let claims: RequiredClaims = serde_json::from_slice(&payload)?;
-
-        if claims.get_audience() != self.client_id {
-            return Err(Error::InvalidToken);
-        }
-        let issuer = claims.get_issuer();
-        if issuer != "https://accounts.google.com" && issuer != "accounts.google.com" {
-            return Err(Error::InvalidToken);
-        }
-        let current_timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-        if self.check_expiration && claims.get_expires_at() < current_timestamp {
-            return Err(Error::Expired);
-        }
-        if claims.get_issued_at() > claims.get_expires_at() {
-            return Err(Error::InvalidToken);
-        }
-        let decoded_payload: P = serde_json::from_slice(&payload)?;
-        Ok(Token::new(claims, decoded_payload))
-    }
-
-    pub async fn verify_token(&self, token_string: &str) -> Result<Token<()>, Error> {
-        self.verify_token_with_payload::<()>(token_string).await
-    }
-
-    pub async fn verify_id_token(&self, token_string: &str) -> Result<Token<IdPayload>, Error> {
-        self.verify_token_with_payload(token_string).await
+    pub fn new(client_id: &str) -> GenericClient<KP> {
+        GenericClientBuilder::new(client_id).build()
     }
 }
 
-pub struct Client {
-    client_id: String,
-    key_provider: Arc<Mutex<dyn KeyProvider + Send>>,
-    check_expiration: bool,
-}
-
-impl Client {
-    pub fn builder(client_id: &str) -> ClientBuilder {
-        ClientBuilder::new(client_id)
-    }
-
-    pub fn new(client_id: &str) -> Client {
-        ClientBuilder::new(client_id).build()
-    }
-
+impl<KP: KeyProvider> GenericClient<KP> {
     pub fn verify_token_with_payload<P>(&self, token_string: &str) -> Result<Token<P>, Error>
     where
         for<'a> P: DeserializeTrait<'a>,
     {
-        let mut segments = token_string.split('.');
-        let encoded_header = segments.next().ok_or(Error::InvalidToken)?;
-        let encoded_payload = segments.next().ok_or(Error::InvalidToken)?;
-        let encoded_signature = segments.next().ok_or(Error::InvalidToken)?;
-
-        let header: Header = serde_json::from_slice(&base64_decode(&encoded_header)?)?;
-
-        let key = match self.key_provider.lock().unwrap().get_key(&header.key_id) {
-            Ok(Some(key)) => key,
-            Ok(None) => return Err(Error::InvalidToken),
-            Err(_) => return Err(Error::RetrieveKeyFailure),
-        };
-        let signed_body = format!("{}.{}", encoded_header, encoded_payload);
-        let signature = base64_decode(&encoded_signature)?;
-        key.verify(signed_body.as_bytes(), &signature)?;
-        let payload = base64_decode(&encoded_payload)?;
-        let claims: RequiredClaims = serde_json::from_slice(&payload)?;
-
-        if claims.get_audience() != self.client_id {
-            return Err(Error::InvalidToken);
-        }
-        let issuer = claims.get_issuer();
-        if issuer != "https://accounts.google.com" && issuer != "accounts.google.com" {
-            return Err(Error::InvalidToken);
-        }
-        let current_timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-        if self.check_expiration && claims.get_expires_at() < current_timestamp {
-            return Err(Error::Expired);
-        }
-        if claims.get_issued_at() > claims.get_expires_at() {
-            return Err(Error::InvalidToken);
-        }
-        let decoded_payload: P = serde_json::from_slice(&payload)?;
-        Ok(Token::new(claims, decoded_payload))
+        let unverified_token = UnverifiedToken::<P>::validate(token_string, self.check_expiration, &self.client_id)?;
+        unverified_token.verify(&self.key_provider)
     }
 
     pub fn verify_token(&self, token_string: &str) -> Result<Token<()>, Error> {
@@ -216,6 +79,95 @@ impl Client {
 
     pub fn verify_id_token(&self, token_string: &str) -> Result<Token<IdPayload>, Error> {
         self.verify_token_with_payload(token_string)
+    }
+}
+
+impl<KP: AsyncKeyProvider> GenericClient<KP> {
+    pub async fn verify_token_with_payload_async<P>(&self, token_string: &str) -> Result<Token<P>, Error>
+    where
+        for<'a> P: DeserializeTrait<'a>,
+    {
+        let unverified_token = UnverifiedToken::<P>::validate(token_string, self.check_expiration, &self.client_id)?;
+        unverified_token.verify_async(&self.key_provider).await
+    }
+
+    pub async fn verify_token_async(&self, token_string: &str) -> Result<Token<()>, Error> {
+        self.verify_token_with_payload_async::<()>(token_string).await
+    }
+
+    pub async fn verify_id_token_async(&self, token_string: &str) -> Result<Token<IdPayload>, Error> {
+        self.verify_token_with_payload_async(token_string).await
+    }
+}
+
+struct UnverifiedToken<P> {
+    header: Header,
+    signed_body: String,
+    signature: Vec<u8>,
+    claims: RequiredClaims,
+    json_payload: P
+}
+
+impl<P> UnverifiedToken<P>
+where
+    for<'a> P: DeserializeTrait<'a>
+{
+    fn validate(token_string: &str, check_expiration: bool, client_id: &str) -> Result<Self, Error> {
+        let mut segments = token_string.split('.');
+        let encoded_header = segments.next().ok_or(Error::InvalidToken)?;
+        let encoded_payload = segments.next().ok_or(Error::InvalidToken)?;
+        let encoded_signature = segments.next().ok_or(Error::InvalidToken)?;
+
+        let header: Header = serde_json::from_slice(&base64_decode(&encoded_header)?)?;
+        let signed_body = format!("{}.{}", encoded_header, encoded_payload);
+        let signature = base64_decode(&encoded_signature)?;
+        let payload = base64_decode(&encoded_payload)?;
+        let claims: RequiredClaims = serde_json::from_slice(&payload)?;
+        if claims.get_audience() != client_id {
+            return Err(Error::InvalidToken);
+        }
+        let issuer = claims.get_issuer();
+        if issuer != "https://accounts.google.com" && issuer != "accounts.google.com" {
+            return Err(Error::InvalidToken);
+        }
+        let current_timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        if check_expiration && claims.get_expires_at() < current_timestamp {
+            return Err(Error::Expired);
+        }
+        if claims.get_issued_at() > claims.get_expires_at() {
+            return Err(Error::InvalidToken);
+        }
+        let json_payload: P = serde_json::from_slice(&payload)?;
+        Ok(Self {
+            claims,
+            signature,
+            signed_body,
+            json_payload,
+            header
+        })
+    }
+}
+
+impl<P> UnverifiedToken<P> {
+    pub fn verify<KP: KeyProvider>(self, key_provider: &Arc<Mutex<KP>>) -> Result<Token<P>, Error> {
+        let key_id = self.header.key_id.clone();
+        self.verify_with_key(key_provider.lock().unwrap().get_key(&key_id))
+    }
+    pub async fn verify_async<KP: AsyncKeyProvider>(self, key_provider: &Arc<Mutex<KP>>) ->  Result<Token<P>, Error> {
+        let key_id = self.header.key_id.clone();
+        self.verify_with_key(key_provider.lock().unwrap().get_key_async(&key_id).await)
+    }
+    fn verify_with_key(self, key: Result<Option<JsonWebKey>, ()>) -> Result<Token<P>, Error> {
+        let key = match key {
+            Ok(Some(key)) => key,
+            Ok(None) => return Err(Error::InvalidToken),
+            Err(_) => return Err(Error::RetrieveKeyFailure),
+        };
+        key.verify(self.signed_body.as_bytes(), &self.signature)?;
+        Ok(Token::new(self.claims, self.json_payload))
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,9 +1,9 @@
 use crate::error::Error;
 #[cfg(feature = "async")]
 use crate::key_provider::AsyncKeyProvider;
+use crate::key_provider::GoogleKeyProvider;
 #[cfg(feature = "blocking")]
 use crate::key_provider::KeyProvider;
-use crate::key_provider::GoogleKeyProvider;
 use crate::token::IdPayload;
 use crate::token::Token;
 use crate::unverified_token::UnverifiedToken;

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,6 @@
 use crate::base64_decode;
 use crate::error::Error;
-use crate::key_provider::GoogleKeyProvider;
-use crate::key_provider::KeyProvider;
+use crate::key_provider::{AsyncKeyProvider, GoogleKeyProvider, KeyProvider};
 use crate::token::IdPayload;
 use crate::token::RequiredClaims;
 use crate::token::Token;
@@ -16,6 +15,42 @@ pub struct ClientBuilder {
     client_id: String,
     key_provider: Arc<Mutex<dyn KeyProvider + Send>>,
     check_expiration: bool,
+}
+
+pub struct AsyncClientBuilder {
+    client_id: String,
+    key_provider: Arc<Mutex<dyn AsyncKeyProvider + Send>>,
+    check_expiration: bool,
+}
+
+impl AsyncClientBuilder {
+    pub fn new(client_id: &str) -> AsyncClientBuilder {
+        AsyncClientBuilder {
+            client_id: client_id.to_owned(),
+            key_provider: Arc::new(Mutex::new(GoogleKeyProvider::new())),
+            check_expiration: true,
+        }
+    }
+    pub fn custom_key_provider<T: AsyncKeyProvider + Send + 'static>(
+        mut self,
+        provider: T,
+    ) -> Self {
+        self.key_provider = Arc::new(Mutex::new(provider));
+        self
+    }
+
+    pub fn unsafe_ignore_expiration(mut self) -> Self {
+        self.check_expiration = false;
+        self
+    }
+
+    pub fn build(self) -> AsyncClient {
+        AsyncClient {
+            client_id: self.client_id,
+            key_provider: self.key_provider,
+            check_expiration: self.check_expiration,
+        }
+    }
 }
 
 impl ClientBuilder {
@@ -42,6 +77,81 @@ impl ClientBuilder {
             key_provider: self.key_provider,
             check_expiration: self.check_expiration,
         }
+    }
+}
+
+pub struct AsyncClient {
+    client_id: String,
+    key_provider: Arc<Mutex<dyn AsyncKeyProvider + Send>>,
+    check_expiration: bool,
+}
+
+impl AsyncClient {
+    pub fn builder(client_id: &str) -> AsyncClientBuilder {
+        AsyncClientBuilder::new(client_id)
+    }
+
+    pub fn new(client_id: &str) -> AsyncClient {
+        AsyncClientBuilder::new(client_id).build()
+    }
+
+    pub async fn verify_token_with_payload<P>(&self, token_string: &str) -> Result<Token<P>, Error>
+    where
+        for<'a> P: Deserialize<'a>,
+    {
+        let mut segments = token_string.split('.');
+        let encoded_header = segments.next().ok_or(Error::InvalidToken)?;
+        let encoded_payload = segments.next().ok_or(Error::InvalidToken)?;
+        let encoded_signature = segments.next().ok_or(Error::InvalidToken)?;
+
+        let header: Header = serde_json::from_slice(&base64_decode(&encoded_header)?)?;
+
+        let key = match self
+            .key_provider
+            .lock()
+            .unwrap()
+            .get_key_async(&header.key_id)
+            .await
+        {
+            Ok(Some(key)) => key,
+            Ok(None) => return Err(Error::InvalidToken),
+            Err(_) => return Err(Error::RetrieveKeyFailure),
+        };
+        let signed_body = format!("{}.{}", encoded_header, encoded_payload);
+        let signature = base64_decode(&encoded_signature)?;
+        key.verify(signed_body.as_bytes(), &signature)?;
+        let payload = base64_decode(&encoded_payload)?;
+        let claims: RequiredClaims = serde_json::from_slice(&payload)?;
+
+        if claims.get_audience() != self.client_id {
+            return Err(Error::InvalidToken);
+        }
+        let issuer = claims.get_issuer();
+        if issuer != "https://accounts.google.com" && issuer != "accounts.google.com" {
+            return Err(Error::InvalidToken);
+        }
+        let current_timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        if self.check_expiration {
+            if claims.get_expires_at() < current_timestamp {
+                return Err(Error::Expired);
+            }
+        }
+        if claims.get_issued_at() > claims.get_expires_at() {
+            return Err(Error::InvalidToken);
+        }
+        let decoded_payload: P = serde_json::from_slice(&payload)?;
+        Ok(Token::new(claims, decoded_payload))
+    }
+
+    pub async fn verify_token(&self, token_string: &str) -> Result<Token<()>, Error> {
+        self.verify_token_with_payload::<()>(token_string).await
+    }
+
+    pub async fn verify_id_token(&self, token_string: &str) -> Result<Token<IdPayload>, Error> {
+        self.verify_token_with_payload(token_string).await
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -96,7 +96,7 @@ impl AsyncClient {
 
     pub async fn verify_token_with_payload<P>(&self, token_string: &str) -> Result<Token<P>, Error>
     where
-        for<'a> P: Deserialize<'a>,
+        for<'a> P: DeserializeTrait<'a>,
     {
         let mut segments = token_string.split('.');
         let encoded_header = segments.next().ok_or(Error::InvalidToken)?;
@@ -133,10 +133,8 @@ impl AsyncClient {
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_secs();
-        if self.check_expiration {
-            if claims.get_expires_at() < current_timestamp {
-                return Err(Error::Expired);
-            }
+        if self.check_expiration && claims.get_expires_at() < current_timestamp {
+            return Err(Error::Expired);
         }
         if claims.get_issued_at() > claims.get_expires_at() {
             return Err(Error::InvalidToken);

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,9 @@
 use crate::error::Error;
 #[cfg(feature = "async")]
 use crate::key_provider::AsyncKeyProvider;
-use crate::key_provider::{GoogleKeyProvider, KeyProvider};
+#[cfg(feature = "blocking")]
+use crate::key_provider::KeyProvider;
+use crate::key_provider::GoogleKeyProvider;
 use crate::token::IdPayload;
 use crate::token::Token;
 use crate::unverified_token::UnverifiedToken;
@@ -62,6 +64,7 @@ impl<KP: Default> GenericClient<KP> {
     }
 }
 
+#[cfg(feature = "blocking")]
 impl<KP: KeyProvider> GenericClient<KP> {
     pub fn verify_token_with_payload<P>(&self, token_string: &str) -> Result<Token<P>, Error>
     where

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,4 +1,4 @@
-use serde_derive::{Serialize, Deserialize};
+use serde_derive::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Debug)]
 pub struct Header {

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,0 +1,7 @@
+use serde_derive::{Serialize, Deserialize};
+
+#[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub struct Header {
+    #[serde(rename = "kid")]
+    pub key_id: String,
+}

--- a/src/key_provider.rs
+++ b/src/key_provider.rs
@@ -21,13 +21,16 @@ pub struct GoogleKeyProvider {
     expiration_time: Instant,
 }
 
-impl GoogleKeyProvider {
-    pub fn new() -> GoogleKeyProvider {
-        GoogleKeyProvider {
+impl Default for GoogleKeyProvider {
+    fn default() -> Self {
+        Self {
             cached: None,
             expiration_time: Instant::now(),
         }
     }
+}
+
+impl GoogleKeyProvider {
     fn process_response(&mut self, headers: &HeaderMap, text: &str) -> Result<&JsonWebKeySet, ()> {
         let mut expiration_time = None;
         let x = headers.get_all(CACHE_CONTROL);
@@ -81,7 +84,7 @@ impl AsyncKeyProvider for GoogleKeyProvider {
 
 #[test]
 pub fn test_google_provider() {
-    let mut provider = GoogleKeyProvider::new();
+    let mut provider = GoogleKeyProvider::default();
     assert!(provider.get_key("test").is_ok());
     assert!(provider.get_key("test").is_ok());
 }
@@ -89,7 +92,7 @@ pub fn test_google_provider() {
 #[cfg(test)]
 #[tokio::test]
 async fn test_google_provider_async() {
-    let mut provider = GoogleKeyProvider::new();
+    let mut provider = GoogleKeyProvider::default();
     assert!(provider.get_key_async("test").await.is_ok());
     assert!(provider.get_key_async("test").await.is_ok());
 }

--- a/src/key_provider.rs
+++ b/src/key_provider.rs
@@ -8,6 +8,7 @@ use std::time::Instant;
 
 const GOOGLE_CERT_URL: &str = "https://www.googleapis.com/oauth2/v3/certs";
 
+#[cfg(feature = "blocking")]
 pub trait KeyProvider {
     fn get_key(&mut self, key_id: &str) -> Result<Option<JsonWebKey>, ()>;
 }
@@ -48,6 +49,7 @@ impl GoogleKeyProvider {
         }
         Ok(self.cached.as_ref().unwrap())
     }
+    #[cfg(feature = "blocking")]
     pub fn download_keys(&mut self) -> Result<&JsonWebKeySet, ()> {
         let result = reqwest::blocking::get(GOOGLE_CERT_URL).map_err(|_| ())?;
         self.process_response(&result.headers().clone(), &result.text().map_err(|_| ())?)
@@ -62,6 +64,7 @@ impl GoogleKeyProvider {
     }
 }
 
+#[cfg(feature = "blocking")]
 impl KeyProvider for GoogleKeyProvider {
     fn get_key(&mut self, key_id: &str) -> Result<Option<JsonWebKey>, ()> {
         if let Some(ref cached_keys) = self.cached {
@@ -86,6 +89,7 @@ impl AsyncKeyProvider for GoogleKeyProvider {
     }
 }
 
+#[cfg(feature = "blocking")]
 #[test]
 pub fn test_google_provider() {
     let mut provider = GoogleKeyProvider::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,8 @@ mod test;
 
 mod algorithm;
 mod client;
-mod header;
 mod error;
+mod header;
 mod jwk;
 mod key_provider;
 mod token;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ mod jwk;
 mod key_provider;
 mod token;
 
-pub use crate::client::Client;
+pub use crate::client::{AsyncClient, Client};
 pub use crate::token::{IdPayload, RequiredClaims, Token};
 pub use error::Error;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ mod jwk;
 mod key_provider;
 mod token;
 
-pub use crate::client::{AsyncClient, Client};
+pub use crate::client::Client;
 pub use crate::token::{IdPayload, RequiredClaims, Token};
 pub use error::Error;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,12 @@ mod test;
 
 mod algorithm;
 mod client;
+mod header;
 mod error;
 mod jwk;
 mod key_provider;
 mod token;
+mod unverified_token;
 
 pub use crate::client::Client;
 pub use crate::token::{IdPayload, RequiredClaims, Token};

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,8 +1,10 @@
 use super::*;
-use crate::error::Error;
 use crate::jwk::JsonWebKey;
 use crate::jwk::JsonWebKeySet;
 use crate::key_provider::KeyProvider;
+use crate::{client::AsyncClient, error::Error, key_provider::AsyncKeyProvider};
+
+use async_trait::async_trait;
 
 const TOKEN: &'static str = "eyJhbGciOiJSUzI1NiIsImtpZCI6ImE3NDhlOWY3NjcxNTlmNjY3YTAyMjMzMThkZTBiMjMyOWU1NDQzNjIifQ.eyJhenAiOiIzNzc3MjExNzQwOC1xanFvOWhjYTUxM3BkY3VudW10N2drMDhpaTZ0ZThpcy5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbSIsImF1ZCI6IjM3NzcyMTE3NDA4LXFqcW85aGNhNTEzcGRjdW51bXQ3Z2swOGlpNnRlOGlzLmFwcHMuZ29vZ2xldXNlcmNvbnRlbnQuY29tIiwic3ViIjoiMTA3MDY3MzYxNTAzOTU0NDc0NDg4IiwiZW1haWwiOiJmdWNoc25qQGdtYWlsLmNvbSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJhdF9oYXNoIjoiaTBOWk5kYWp3UklJbDJvUk9zUUptUSIsImV4cCI6MTUyNjQ5MjUzMywiaXNzIjoiYWNjb3VudHMuZ29vZ2xlLmNvbSIsImp0aSI6IjNmMjc1YjRiY2JmZDU0Y2IxNjZmMzcxNWQ1NTBkMWNmMmUxYThiZGEiLCJpYXQiOjE1MjY0ODg5MzMsIm5hbWUiOiJOYXRoYW4gRm94IiwicGljdHVyZSI6Imh0dHBzOi8vbGg1Lmdvb2dsZXVzZXJjb250ZW50LmNvbS8tbEJSLWE3Z2gwdFkvQUFBQUFBQUFBQUkvQUFBQUFBQUFFUk0vNDFHUk43cDNNVzQvczk2LWMvcGhvdG8uanBnIiwiZ2l2ZW5fbmFtZSI6Ik5hdGhhbiIsImZhbWlseV9uYW1lIjoiRm94IiwibG9jYWxlIjoiZW4ifQ.pOoIMLZgZIFP-fgQirCRRK31ap_CO7WZDeHge-U5GoAvF0VdkoSDSL-1-8d93qKb8IWzi2iS2MgaLekcX8eELM5x39Th1sBwjQGjYr5AXmqE53WDQiqvKzrz-BZ3ay0uSAMllxWfFi62BkSP3m1HJNWyUWrUf6GyI-Vy024dtrX9Qq_BOznJWbQVhHf5aA7x5AAoLHZ_PmzxbUlDQ7Go6FD7sgkoksZI4Cp77HZJMXXGVOrvvXJkpctTcuBZ2P-2filLmb29JIm0e4McOjeHQTV7XNGdzTZoyeSZcU5xTVFQK89e-SIPHKyaL7TAr_faBbTGzVryYfa2VFyKi7Z9gA";
 const JWKS: &'static str = r#"{
@@ -32,6 +34,14 @@ struct TestKeyProvider;
 
 impl KeyProvider for TestKeyProvider {
     fn get_key(&mut self, key_id: &str) -> Result<Option<JsonWebKey>, ()> {
+        let set: JsonWebKeySet = serde_json::from_str(JWKS).unwrap();
+        Ok(set.get_key(key_id))
+    }
+}
+
+#[async_trait]
+impl AsyncKeyProvider for TestKeyProvider {
+    async fn get_key_async(&mut self, key_id: &str) -> Result<Option<JsonWebKey>, ()> {
         let set: JsonWebKeySet = serde_json::from_str(JWKS).unwrap();
         Ok(set.get_key(key_id))
     }
@@ -73,6 +83,55 @@ pub fn test_id_token() {
         .build();
     let id_token = client
         .verify_id_token(TOKEN)
+        .expect("id token should be valid");
+    assert_eq!(id_token.get_claims().get_audience(), AUDIENCE);
+    assert_eq!(id_token.get_payload().get_domain(), None);
+    assert_eq!(id_token.get_payload().get_email(), "fuchsnj@gmail.com");
+}
+
+#[tokio::test]
+async fn decode_keys_async() {
+    TestKeyProvider
+        .get_key_async("3f3ef9c7803cd0b8d75247ee0d31fdd5c2cf3812")
+        .await
+        .unwrap();
+    TestKeyProvider
+        .get_key_async("a748e9f767159f667a0223318de0b2329e544362")
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_client_async() {
+    let client = AsyncClient::builder(
+        "37772117408-qjqo9hca513pdcunumt7gk08ii6te8is.apps.googleusercontent.com",
+    )
+    .custom_key_provider(TestKeyProvider)
+    .build();
+    assert_eq!(
+        client.verify_token(TOKEN).await.map(|_| ()),
+        Err(Error::Expired)
+    );
+}
+
+#[tokio::test]
+async fn test_client_invalid_client_id_async() {
+    let client = AsyncClient::builder("invalid client id")
+        .custom_key_provider(TestKeyProvider)
+        .build();
+    let result = client.verify_token(TOKEN).await.map(|_| ());
+    assert_eq!(result, Err(Error::InvalidToken))
+}
+
+#[tokio::test]
+async fn test_id_token_async() {
+    let client = AsyncClient::builder(AUDIENCE)
+        .custom_key_provider(TestKeyProvider)
+        .unsafe_ignore_expiration()
+        .build();
+    let id_token = client
+        .verify_id_token(TOKEN)
+        .await
         .expect("id token should be valid");
     assert_eq!(id_token.get_claims().get_audience(), AUDIENCE);
     assert_eq!(id_token.get_payload().get_domain(), None);

--- a/src/test.rs
+++ b/src/test.rs
@@ -4,6 +4,7 @@ use crate::jwk::JsonWebKey;
 use crate::jwk::JsonWebKeySet;
 #[cfg(feature = "async")]
 use crate::key_provider::AsyncKeyProvider;
+#[cfg(feature = "blocking")]
 use crate::key_provider::KeyProvider;
 
 #[cfg(feature = "async")]
@@ -35,6 +36,7 @@ const AUDIENCE: &'static str =
 
 struct TestKeyProvider;
 
+#[cfg(feature = "blocking")]
 impl KeyProvider for TestKeyProvider {
     fn get_key(&mut self, key_id: &str) -> Result<Option<JsonWebKey>, ()> {
         let set: JsonWebKeySet = serde_json::from_str(JWKS).unwrap();
@@ -51,6 +53,7 @@ impl AsyncKeyProvider for TestKeyProvider {
     }
 }
 
+#[cfg(feature = "blocking")]
 #[test]
 pub fn decode_keys() {
     TestKeyProvider
@@ -61,6 +64,7 @@ pub fn decode_keys() {
         .unwrap();
 }
 
+#[cfg(feature = "blocking")]
 #[test]
 pub fn test_client() {
     let client =
@@ -70,6 +74,7 @@ pub fn test_client() {
     assert_eq!(client.verify_token(TOKEN).map(|_| ()), Err(Error::Expired));
 }
 
+#[cfg(feature = "blocking")]
 #[test]
 pub fn test_client_invalid_client_id() {
     let client = Client::builder("invalid client id")
@@ -79,6 +84,7 @@ pub fn test_client_invalid_client_id() {
     assert_eq!(result, Err(Error::InvalidToken))
 }
 
+#[cfg(feature = "blocking")]
 #[test]
 pub fn test_id_token() {
     let client = Client::builder(AUDIENCE)

--- a/src/test.rs
+++ b/src/test.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::jwk::JsonWebKey;
 use crate::jwk::JsonWebKeySet;
 use crate::key_provider::KeyProvider;
-use crate::{client::AsyncClient, error::Error, key_provider::AsyncKeyProvider};
+use crate::{error::Error, key_provider::AsyncKeyProvider};
 
 use async_trait::async_trait;
 
@@ -103,34 +103,34 @@ async fn decode_keys_async() {
 
 #[tokio::test]
 async fn test_client_async() {
-    let client = AsyncClient::builder(
+    let client = Client::builder(
         "37772117408-qjqo9hca513pdcunumt7gk08ii6te8is.apps.googleusercontent.com",
     )
     .custom_key_provider(TestKeyProvider)
     .build();
     assert_eq!(
-        client.verify_token(TOKEN).await.map(|_| ()),
+        client.verify_token_async(TOKEN).await.map(|_| ()),
         Err(Error::Expired)
     );
 }
 
 #[tokio::test]
 async fn test_client_invalid_client_id_async() {
-    let client = AsyncClient::builder("invalid client id")
+    let client = Client::builder("invalid client id")
         .custom_key_provider(TestKeyProvider)
         .build();
-    let result = client.verify_token(TOKEN).await.map(|_| ());
+    let result = client.verify_token_async(TOKEN).await.map(|_| ());
     assert_eq!(result, Err(Error::InvalidToken))
 }
 
 #[tokio::test]
 async fn test_id_token_async() {
-    let client = AsyncClient::builder(AUDIENCE)
+    let client = Client::builder(AUDIENCE)
         .custom_key_provider(TestKeyProvider)
         .unsafe_ignore_expiration()
         .build();
     let id_token = client
-        .verify_id_token(TOKEN)
+        .verify_id_token_async(TOKEN)
         .await
         .expect("id token should be valid");
     assert_eq!(id_token.get_claims().get_audience(), AUDIENCE);

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,9 +1,12 @@
 use super::*;
+use crate::error::Error;
 use crate::jwk::JsonWebKey;
 use crate::jwk::JsonWebKeySet;
+#[cfg(feature = "async")]
+use crate::key_provider::AsyncKeyProvider;
 use crate::key_provider::KeyProvider;
-use crate::{error::Error, key_provider::AsyncKeyProvider};
 
+#[cfg(feature = "async")]
 use async_trait::async_trait;
 
 const TOKEN: &'static str = "eyJhbGciOiJSUzI1NiIsImtpZCI6ImE3NDhlOWY3NjcxNTlmNjY3YTAyMjMzMThkZTBiMjMyOWU1NDQzNjIifQ.eyJhenAiOiIzNzc3MjExNzQwOC1xanFvOWhjYTUxM3BkY3VudW10N2drMDhpaTZ0ZThpcy5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbSIsImF1ZCI6IjM3NzcyMTE3NDA4LXFqcW85aGNhNTEzcGRjdW51bXQ3Z2swOGlpNnRlOGlzLmFwcHMuZ29vZ2xldXNlcmNvbnRlbnQuY29tIiwic3ViIjoiMTA3MDY3MzYxNTAzOTU0NDc0NDg4IiwiZW1haWwiOiJmdWNoc25qQGdtYWlsLmNvbSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJhdF9oYXNoIjoiaTBOWk5kYWp3UklJbDJvUk9zUUptUSIsImV4cCI6MTUyNjQ5MjUzMywiaXNzIjoiYWNjb3VudHMuZ29vZ2xlLmNvbSIsImp0aSI6IjNmMjc1YjRiY2JmZDU0Y2IxNjZmMzcxNWQ1NTBkMWNmMmUxYThiZGEiLCJpYXQiOjE1MjY0ODg5MzMsIm5hbWUiOiJOYXRoYW4gRm94IiwicGljdHVyZSI6Imh0dHBzOi8vbGg1Lmdvb2dsZXVzZXJjb250ZW50LmNvbS8tbEJSLWE3Z2gwdFkvQUFBQUFBQUFBQUkvQUFBQUFBQUFFUk0vNDFHUk43cDNNVzQvczk2LWMvcGhvdG8uanBnIiwiZ2l2ZW5fbmFtZSI6Ik5hdGhhbiIsImZhbWlseV9uYW1lIjoiRm94IiwibG9jYWxlIjoiZW4ifQ.pOoIMLZgZIFP-fgQirCRRK31ap_CO7WZDeHge-U5GoAvF0VdkoSDSL-1-8d93qKb8IWzi2iS2MgaLekcX8eELM5x39Th1sBwjQGjYr5AXmqE53WDQiqvKzrz-BZ3ay0uSAMllxWfFi62BkSP3m1HJNWyUWrUf6GyI-Vy024dtrX9Qq_BOznJWbQVhHf5aA7x5AAoLHZ_PmzxbUlDQ7Go6FD7sgkoksZI4Cp77HZJMXXGVOrvvXJkpctTcuBZ2P-2filLmb29JIm0e4McOjeHQTV7XNGdzTZoyeSZcU5xTVFQK89e-SIPHKyaL7TAr_faBbTGzVryYfa2VFyKi7Z9gA";
@@ -39,6 +42,7 @@ impl KeyProvider for TestKeyProvider {
     }
 }
 
+#[cfg(feature = "async")]
 #[async_trait]
 impl AsyncKeyProvider for TestKeyProvider {
     async fn get_key_async(&mut self, key_id: &str) -> Result<Option<JsonWebKey>, ()> {
@@ -89,6 +93,7 @@ pub fn test_id_token() {
     assert_eq!(id_token.get_payload().get_email(), "fuchsnj@gmail.com");
 }
 
+#[cfg(feature = "async")]
 #[tokio::test]
 async fn decode_keys_async() {
     TestKeyProvider
@@ -101,19 +106,20 @@ async fn decode_keys_async() {
         .unwrap();
 }
 
+#[cfg(feature = "async")]
 #[tokio::test]
 async fn test_client_async() {
-    let client = Client::builder(
-        "37772117408-qjqo9hca513pdcunumt7gk08ii6te8is.apps.googleusercontent.com",
-    )
-    .custom_key_provider(TestKeyProvider)
-    .build();
+    let client =
+        Client::builder("37772117408-qjqo9hca513pdcunumt7gk08ii6te8is.apps.googleusercontent.com")
+            .custom_key_provider(TestKeyProvider)
+            .build();
     assert_eq!(
         client.verify_token_async(TOKEN).await.map(|_| ()),
         Err(Error::Expired)
     );
 }
 
+#[cfg(feature = "async")]
 #[tokio::test]
 async fn test_client_invalid_client_id_async() {
     let client = Client::builder("invalid client id")
@@ -123,6 +129,7 @@ async fn test_client_invalid_client_id_async() {
     assert_eq!(result, Err(Error::InvalidToken))
 }
 
+#[cfg(feature = "async")]
 #[tokio::test]
 async fn test_id_token_async() {
     let client = Client::builder(AUDIENCE)

--- a/src/unverified_token.rs
+++ b/src/unverified_token.rs
@@ -9,10 +9,7 @@ use serde::Deserialize;
 use crate::key_provider::AsyncKeyProvider;
 #[cfg(feature = "blocking")]
 use crate::key_provider::KeyProvider;
-use crate::{
-    base64_decode, header::Header, jwk::JsonWebKey, Error,
-    RequiredClaims, Token,
-};
+use crate::{base64_decode, header::Header, jwk::JsonWebKey, Error, RequiredClaims, Token};
 
 pub struct UnverifiedToken<P> {
     header: Header,

--- a/src/unverified_token.rs
+++ b/src/unverified_token.rs
@@ -1,0 +1,76 @@
+use std::{sync::{Arc, Mutex}, time::{SystemTime, UNIX_EPOCH}};
+
+use serde::Deserialize;
+
+use crate::{Error, jwk::JsonWebKey, RequiredClaims, Token, base64_decode, header::Header, key_provider::AsyncKeyProvider, key_provider::KeyProvider};
+
+pub struct UnverifiedToken<P> {
+    header: Header,
+    signed_body: String,
+    signature: Vec<u8>,
+    claims: RequiredClaims,
+    json_payload: P
+}
+
+impl<P> UnverifiedToken<P>
+where
+    for<'a> P: Deserialize<'a>
+{
+    pub fn validate(token_string: &str, check_expiration: bool, client_id: &str) -> Result<Self, Error> {
+        let mut segments = token_string.split('.');
+        let encoded_header = segments.next().ok_or(Error::InvalidToken)?;
+        let encoded_payload = segments.next().ok_or(Error::InvalidToken)?;
+        let encoded_signature = segments.next().ok_or(Error::InvalidToken)?;
+
+        let header: Header = serde_json::from_slice(&base64_decode(&encoded_header)?)?;
+        let signed_body = format!("{}.{}", encoded_header, encoded_payload);
+        let signature = base64_decode(&encoded_signature)?;
+        let payload = base64_decode(&encoded_payload)?;
+        let claims: RequiredClaims = serde_json::from_slice(&payload)?;
+        if claims.get_audience() != client_id {
+            return Err(Error::InvalidToken);
+        }
+        let issuer = claims.get_issuer();
+        if issuer != "https://accounts.google.com" && issuer != "accounts.google.com" {
+            return Err(Error::InvalidToken);
+        }
+        let current_timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        if check_expiration && claims.get_expires_at() < current_timestamp {
+            return Err(Error::Expired);
+        }
+        if claims.get_issued_at() > claims.get_expires_at() {
+            return Err(Error::InvalidToken);
+        }
+        let json_payload: P = serde_json::from_slice(&payload)?;
+        Ok(Self {
+            claims,
+            signature,
+            signed_body,
+            json_payload,
+            header
+        })
+    }
+}
+
+impl<P> UnverifiedToken<P> {
+    pub fn verify<KP: KeyProvider>(self, key_provider: &Arc<Mutex<KP>>) -> Result<Token<P>, Error> {
+        let key_id = self.header.key_id.clone();
+        self.verify_with_key(key_provider.lock().unwrap().get_key(&key_id))
+    }
+    pub async fn verify_async<KP: AsyncKeyProvider>(self, key_provider: &Arc<Mutex<KP>>) ->  Result<Token<P>, Error> {
+        let key_id = self.header.key_id.clone();
+        self.verify_with_key(key_provider.lock().unwrap().get_key_async(&key_id).await)
+    }
+    fn verify_with_key(self, key: Result<Option<JsonWebKey>, ()>) -> Result<Token<P>, Error> {
+        let key = match key {
+            Ok(Some(key)) => key,
+            Ok(None) => return Err(Error::InvalidToken),
+            Err(_) => return Err(Error::RetrieveKeyFailure),
+        };
+        key.verify(self.signed_body.as_bytes(), &self.signature)?;
+        Ok(Token::new(self.claims, self.json_payload))
+    }
+}

--- a/src/unverified_token.rs
+++ b/src/unverified_token.rs
@@ -7,8 +7,10 @@ use serde::Deserialize;
 
 #[cfg(feature = "async")]
 use crate::key_provider::AsyncKeyProvider;
+#[cfg(feature = "blocking")]
+use crate::key_provider::KeyProvider;
 use crate::{
-    base64_decode, header::Header, jwk::JsonWebKey, key_provider::KeyProvider, Error,
+    base64_decode, header::Header, jwk::JsonWebKey, Error,
     RequiredClaims, Token,
 };
 
@@ -68,6 +70,7 @@ where
 }
 
 impl<P> UnverifiedToken<P> {
+    #[cfg(feature = "blocking")]
     pub fn verify<KP: KeyProvider>(self, key_provider: &Arc<Mutex<KP>>) -> Result<Token<P>, Error> {
         let key_id = self.header.key_id.clone();
         self.verify_with_key(key_provider.lock().unwrap().get_key(&key_id))


### PR DESCRIPTION
Required within a tokio runtime to prevent thread from panicking on a blocking http request.

When calling e.g. `Client::new("client_id").verify_id_token("id_token")` within a `tokio` runtime, I get the following message.
```
Cannot start a runtime from within a runtime. This happens because a function (like `block_on`) attempted to block the current thread while the thread is being used to drive asynchronous tasks.
```

To solve this I can instead call e.g. `Client::new("client_id").verify_id_token_async("id_token").await`