### PR TITLE
Support Firebase Authentication ID Tokens

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [features]
 default = ["blocking"]
-async = ["async-trait"]
+async = ["async-trait", "tokio"]
 blocking = ["reqwest/blocking"]
 
 [dependencies]
@@ -24,6 +24,8 @@ serde_json = "1.0.48"
 serde_derive = "1.0.104"
 reqwest = {version="0.10.4"}
 headers = "0.3.1"
+tokio = {version = "0.2", optional = true}
 
 [dev-dependencies]
 tokio = {version = "0.2", features = ["macros"]}
+futures = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde_derive = "1.0.104"
 reqwest = {version="0.10.4"}
 headers = "0.3.1"
 tokio = {version = "0.2", optional = true}
+thiserror = "1"
 
 [dev-dependencies]
 tokio = {version = "0.2", features = ["macros"]}

--- a/README.md
+++ b/README.md
@@ -7,18 +7,34 @@ This can be used to verify Google JWT tokens. Google's public keys are automatic
 and cached according to the returned Cache-Control headers. Most requests to verify a token
 through this library will not wait for an HTTP request
 
-For more info: https://developers.google.com/identity/sign-in/web/backend-auth
+This library supports two different Google authentication services: Google Signin and Firebase Authentication
 
-## Quick Start
-```rust
+For more info about Google Signin: https://developers.google.com/identity/sign-in/web/backend-auth
+
+For more info about Firebase Authentication: https://firebase.google.com/docs/auth/admin/verify-id-tokens
+
+## Google Signin Quick Start
+```rustimportimport
  //If you don't have a client id, get one from here: https://console.developers.google.com/
  let client_id = "37772117408-qjqo9hca513pdcunumt7gk08ii6te8is.apps.googleusercontent.com";
  let token = "...";// Obtain a signed token from Google
- let client = Client::new(&client_id);
+ let client = Client::new_google_signin(&client_id);
  let id_token = client.verify_id_token(&token)?;
  
  //use the token to obtain information about the verified user
  let user_id = id_token.get_claims().get_subject();
  let email = id_token.get_payload().get_email();
  let name = id_token.get_payload().get_name();
+```
+
+## Firebase Authentication Quick Start
+```rust
+ //If you don't have a firebase project, create one from here: https://firebase.google.com/
+ let project_id = "jwt-verify";
+ let token = "...";// Obtain a signed token from Google
+ let client = Client::new_firebase(&project_id);
+ let id_token = client.verify_id_token(&token)?;
+ 
+ //use the token to obtain information about the verified user
+ let user_id = id_token.get_claims().get_subject();
 ```

--- a/README.md
+++ b/README.md
@@ -7,14 +7,16 @@ This can be used to verify Google JWT tokens. Google's public keys are automatic
 and cached according to the returned Cache-Control headers. Most requests to verify a token
 through this library will not wait for an HTTP request
 
-This library supports two different Google authentication services: Google Signin and Firebase Authentication
+This library supports two different Google authentication services: Google Signin and Firebase Authentication.
 
 For more info about Google Signin: https://developers.google.com/identity/sign-in/web/backend-auth
 
 For more info about Firebase Authentication: https://firebase.google.com/docs/auth/admin/verify-id-tokens
 
-## Google Signin Quick Start
-```rustimportimport
+The library has two features: `async` and `blocking`. The default is just the `blocking` feature.
+
+## Google Signin Blocking Quick Start
+```rust
  //If you don't have a client id, get one from here: https://console.developers.google.com/
  let client_id = "37772117408-qjqo9hca513pdcunumt7gk08ii6te8is.apps.googleusercontent.com";
  let token = "...";// Obtain a signed token from Google
@@ -27,7 +29,7 @@ For more info about Firebase Authentication: https://firebase.google.com/docs/au
  let name = id_token.get_payload().get_name();
 ```
 
-## Firebase Authentication Quick Start
+## Firebase Authentication Blocking Quick Start
 ```rust
  //If you don't have a firebase project, create one from here: https://firebase.google.com/
  let project_id = "jwt-verify";
@@ -37,4 +39,16 @@ For more info about Firebase Authentication: https://firebase.google.com/docs/au
  
  //use the token to obtain information about the verified user
  let user_id = id_token.get_claims().get_subject();
+```
+
+The `async` feature supports Tokio v0.2 runtime by modifying the above examples. Raise a Github issue if you need other async runtimes supported.
+
+```rust
+let client = Client::google_signin_builder(&client_id).tokio().build();
+let id_token = client.verify_id_token(&token).await?;
+```
+
+```rust
+let client = Client::firebase_builder(&project_id).tokio().build();
+let id_token = client.verify_id_token(&token).await?;
 ```

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -1,0 +1,10 @@
+use serde::Deserialize;
+
+pub trait Claims: Clone
+where
+    for<'a> Self: Deserialize<'a>,
+{
+    fn get_issued_at(&self) -> u64;
+    fn get_expires_at(&self) -> u64;
+    fn get_subject(&self) -> &str;
+}

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -6,5 +6,4 @@ where
 {
     fn get_issued_at(&self) -> u64;
     fn get_expires_at(&self) -> u64;
-    fn get_subject(&self) -> &str;
 }

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -1,9 +1,0 @@
-use serde::Deserialize;
-
-pub trait Claims: Clone
-where
-    for<'a> Self: Deserialize<'a>,
-{
-    fn get_issued_at(&self) -> u64;
-    fn get_expires_at(&self) -> u64;
-}

--- a/src/client.rs
+++ b/src/client.rs
@@ -13,7 +13,10 @@ use crate::{
 };
 use serde::Deserialize;
 
-use std::sync::{Arc, Mutex};
+use std::{
+    fmt::Debug,
+    sync::{Arc, Mutex},
+};
 
 pub type Client = GenericBlockingClient<GoogleSigninKeyProvider, GoogleSigninValidator>;
 
@@ -161,14 +164,13 @@ impl FirebaseClient {
 impl<KP: KeyProvider, V: Validator> GenericBlockingClient<KP, V> {
     pub fn verify_token_with_payload<P>(&self, token_string: &str) -> VerifyTokenResult<V, P>
     where
-        for<'a> P: Deserialize<'a>,
+        for<'a> P: Deserialize<'a> + Debug,
     {
         let unverified_token = UnverifiedToken::<P, _>::validate(
             token_string,
             &self.token_validator,
             self.mocked_timestamp.map_or_else(current_timestamp, Ok)?,
         )?;
-        println!("validated token");
         unverified_token.verify::<KP, V>(&self.key_provider)
     }
 
@@ -188,13 +190,12 @@ type VerifyTokenResult<V, P> =
 impl<KP: AsyncKeyProvider, V: Validator> GenericTokioClient<KP, V> {
     pub async fn verify_token_with_payload<P>(&self, token_string: &str) -> VerifyTokenResult<V, P>
     where
-        for<'a> P: Deserialize<'a>,
+        for<'a> P: Deserialize<'a> + Debug,
     {
         let unverified_token = UnverifiedToken::<P, V::RequiredClaims>::validate(
             token_string,
             &self.token_validator,
-            self.mocked_timestamp
-                .map_or_else(current_timestamp, Ok)?,
+            self.mocked_timestamp.map_or_else(current_timestamp, Ok)?,
         )?;
         unverified_token
             .verify_async::<KP, V>(&self.key_provider)

--- a/src/client.rs
+++ b/src/client.rs
@@ -32,9 +32,13 @@ pub type FirebaseClient =
 type FirebaseClientBuilder =
     GenericBlockingClientBuilder<FirebaseAuthenticationKeyProvider, FirebaseValidator>;
 
-#[cfg(all(test, feature = "async"))]
+#[cfg(feature = "async")]
 pub type GoogleSigninTokioClient =
     GenericTokioClient<GoogleSigninKeyProvider, GoogleSigninValidator>;
+
+#[cfg(feature = "async")]
+pub type FirebaseTokioClient =
+    GenericTokioClient<FirebaseAuthenticationKeyProvider, FirebaseValidator>;
 
 #[cfg(feature = "async")]
 type GenericTokioClient<KP, V> = GenericClient<Arc<tokio::sync::Mutex<KP>>, V>;

--- a/src/client.rs
+++ b/src/client.rs
@@ -147,6 +147,7 @@ impl<KP, V> GenericClientBuilder<KP, V> {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct GenericClient<T, V> {
     token_validator: V,
     key_provider: T,

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,8 @@
 #[cfg(feature = "async")]
 use crate::key_provider::AsyncKeyProvider;
 #[cfg(feature = "blocking")]
-use crate::key_provider::{FirebaseValidator, GoogleSigninValidator, KeyProvider};
+use crate::key_provider::KeyProvider;
+use crate::key_provider::{FirebaseValidator, GoogleSigninValidator};
 use crate::token::Token;
 use crate::unverified_token::UnverifiedToken;
 use crate::{

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,28 +1,145 @@
+use std::time::SystemTimeError;
+
 use crate::algorithm::Algorithm;
 use base64::DecodeError;
 
-#[derive(Debug, PartialEq)]
-pub enum Error {
-    InvalidToken,
+#[derive(Debug)]
+pub enum Error<TCE: TokenClaimsError> {
+    InvalidToken(TokenValidationError<TCE>),
+    Verification(VerificationError),
+    /// If unable to get the current system time
+    CurrentTimestamp(SystemTimeError),
     RetrieveKeyFailure,
+    /// Key with request ID doesn't exist, may have been rotated
+    KeyDoesNotExist,
+}
+
+impl<TCE: TokenClaimsError + PartialEq> PartialEq for Error<TCE> {
+    fn eq(&self, other: &Self) -> bool {
+        matches!((self, other), (Error::InvalidToken(tve1), Error::InvalidToken(tve2)) if tve1 == tve2)
+            || matches!((self, other), (Error::Verification(ve1), Error::Verification(ve2)) if ve1 == ve2)
+            || matches!((self, other), (Error::CurrentTimestamp(ste1), Error::CurrentTimestamp(ste2)) if ste1.duration() == ste2.duration())
+            || matches!(
+                (self, other),
+                (Error::RetrieveKeyFailure, Error::RetrieveKeyFailure)
+                    | (Error::KeyDoesNotExist, Error::KeyDoesNotExist)
+            )
+    }
+}
+
+impl<TCE: TokenClaimsError> From<VerificationError> for Error<TCE> {
+    fn from(ve: VerificationError) -> Self {
+        Self::Verification(ve)
+    }
+}
+
+impl<TCE: TokenClaimsError> From<TokenValidationError<TCE>> for Error<TCE> {
+    fn from(tve: TokenValidationError<TCE>) -> Self {
+        Self::InvalidToken(tve)
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum TokenValidationError<TCE: TokenClaimsError> {
+    /// Token should not be authorized by client given the claims
+    Claims(TCE),
+    /// If unable to get the serialized header
+    Header(TokenSegmentError),
+    /// If unable to get the serialized payload
+    Payload(TokenSegmentError),
+    /// If unable to get the serialized signature
+    Signature(TokenSegmentError),
+    /// If a serialized token segment does not match expected JSON schema
+    Json(JsonDeserializationError),
+}
+
+impl<TCE: TokenClaimsError> From<TCE> for TokenValidationError<TCE> {
+    fn from(tce: TCE) -> Self {
+        Self::Claims(tce)
+    }
+}
+
+pub trait TokenClaimsError {}
+
+#[derive(Debug)]
+pub enum JsonDeserializationError {
+    Header(serde_json::Error),
+    Claims(serde_json::Error),
+    Payload(serde_json::Error),
+}
+
+impl PartialEq for JsonDeserializationError {
+    fn eq(&self, other: &Self) -> bool {
+        matches!((self, other),
+            (JsonDeserializationError::Header(e1), JsonDeserializationError::Header(e2)) |
+            (JsonDeserializationError::Payload(e1), JsonDeserializationError::Payload(e2)) |
+            (JsonDeserializationError::Claims(e1), JsonDeserializationError::Claims(e2)) if e1.to_string() == e2.to_string()
+        )
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum TokenSegmentError {
+    Decoding(DecodeError),
+    Absent,
+}
+
+impl<TCE: TokenClaimsError> From<SystemTimeError> for Error<TCE> {
+    fn from(ste: SystemTimeError) -> Self {
+        Self::CurrentTimestamp(ste)
+    }
+}
+
+impl From<DecodeError> for TokenSegmentError {
+    fn from(de: DecodeError) -> Self {
+        Self::Decoding(de)
+    }
+}
+
+#[derive(Debug)]
+pub enum VerificationError {
     UnsupportedAlgorithm(Algorithm),
-    Expired,
+    Modulus(PublicComponentError),
+    Exponent(PublicComponentError),
+    Cryptography(openssl::error::ErrorStack),
 }
 
-impl From<DecodeError> for Error {
-    fn from(_: DecodeError) -> Self {
-        Error::InvalidToken
+impl PartialEq for VerificationError {
+    fn eq(&self, other: &Self) -> bool {
+        matches!((self, other), (VerificationError::Modulus(pce1), VerificationError::Modulus(pce2)) |
+            (VerificationError::Exponent(pce1), VerificationError::Exponent(pce2)) if pce1 == pce2)
+            || matches!((self, other), (VerificationError::Cryptography(e1), VerificationError::Cryptography(e2)) if e1.to_string() == e2.to_string())
+            || matches!((self, other), (VerificationError::UnsupportedAlgorithm(a1), VerificationError::UnsupportedAlgorithm(a2)) if a1 == a2)
     }
 }
 
-impl From<serde_json::Error> for Error {
-    fn from(_: serde_json::Error) -> Self {
-        Error::InvalidToken
+impl From<openssl::error::ErrorStack> for VerificationError {
+    fn from(e: openssl::error::ErrorStack) -> Self {
+        Self::Cryptography(e)
     }
 }
 
-impl From<openssl::error::ErrorStack> for Error {
-    fn from(_: openssl::error::ErrorStack) -> Self {
-        Error::InvalidToken
+#[derive(Debug)]
+pub enum PublicComponentError {
+    BigNumParse(openssl::error::ErrorStack),
+    Decoding(DecodeError),
+}
+
+impl PartialEq for PublicComponentError {
+    fn eq(&self, other: &Self) -> bool {
+        matches!((self, other), (PublicComponentError::Decoding(de1), PublicComponentError::Decoding(de2)) if de1 == de2)
+            || matches!((self, other), (PublicComponentError::BigNumParse(e1), PublicComponentError::BigNumParse(e2)) if e1.to_string() == e2.to_string())
+    }
+}
+
+impl From<openssl::error::ErrorStack> for PublicComponentError {
+    fn from(e: openssl::error::ErrorStack) -> Self {
+        Self::BigNumParse(e)
+    }
+}
+
+impl From<DecodeError> for PublicComponentError {
+    fn from(de: DecodeError) -> Self {
+        Self::Decoding(de)
     }
 }

--- a/src/firebase_test.rs
+++ b/src/firebase_test.rs
@@ -3,9 +3,10 @@ use crate::key_provider::AsyncKeyProvider;
 #[cfg(feature = "blocking")]
 use crate::key_provider::KeyProvider;
 use crate::{
-    Error, key_provider::FirebaseClaimsError, error::TokenValidationError,
+    error::TokenValidationError,
     jwk::{JsonWebKey, JsonWebKeySet},
-    Client,
+    key_provider::FirebaseClaimsError,
+    Client, Error,
 };
 #[cfg(feature = "async")]
 use async_trait::async_trait;
@@ -80,10 +81,10 @@ fn expired_firebase_token() {
         .custom_key_provider(TestProvider)
         .unsafe_mock_timestamp(AFTER_EXPIRATION)
         .build();
-      assert_eq!(
+    assert_eq!(
         client.verify_id_token(TOKEN).unwrap_err(),
         Error::InvalidToken(TokenValidationError::Claims(FirebaseClaimsError::Expired))
-      );
+    );
 }
 
 #[cfg(feature = "blocking")]
@@ -93,10 +94,12 @@ fn firebase_token_authenticated_in_the_future() {
         .custom_key_provider(TestProvider)
         .unsafe_mock_timestamp(BEFORE_AUTHENTICATING)
         .build();
-      assert_eq!(
+    assert_eq!(
         client.verify_id_token(TOKEN).unwrap_err(),
-        Error::InvalidToken(TokenValidationError::Claims(FirebaseClaimsError::AuthenticatedInTheFuture))
-      );
+        Error::InvalidToken(TokenValidationError::Claims(
+            FirebaseClaimsError::AuthenticatedInTheFuture
+        ))
+    );
 }
 
 #[cfg(feature = "async")]
@@ -119,12 +122,11 @@ async fn expired_firebase_token_async() {
         .unsafe_mock_timestamp(AFTER_EXPIRATION)
         .tokio()
         .build();
-      assert_eq!(
+    assert_eq!(
         client.verify_id_token(TOKEN).await.unwrap_err(),
         Error::InvalidToken(TokenValidationError::Claims(FirebaseClaimsError::Expired))
-      );
+    );
 }
-
 
 #[cfg(feature = "async")]
 #[tokio::test]
@@ -134,8 +136,10 @@ async fn firebase_token_authenticated_in_the_future_async() {
         .unsafe_mock_timestamp(BEFORE_AUTHENTICATING)
         .tokio()
         .build();
-      assert_eq!(
+    assert_eq!(
         client.verify_id_token(TOKEN).await.unwrap_err(),
-        Error::InvalidToken(TokenValidationError::Claims(FirebaseClaimsError::AuthenticatedInTheFuture))
-      );
+        Error::InvalidToken(TokenValidationError::Claims(
+            FirebaseClaimsError::AuthenticatedInTheFuture
+        ))
+    );
 }

--- a/src/firebase_test.rs
+++ b/src/firebase_test.rs
@@ -83,7 +83,10 @@ fn expired_firebase_token() {
         .build();
     assert_eq!(
         client.verify_id_token(TOKEN).unwrap_err(),
-        Error::InvalidToken(TokenValidationError::Claims(FirebaseClaimsError::Expired))
+        Error::InvalidToken(TokenValidationError::Claims(FirebaseClaimsError::Expired {
+            now: AFTER_EXPIRATION,
+            exp: 1607565474
+        }))
     );
 }
 
@@ -97,7 +100,10 @@ fn firebase_token_authenticated_in_the_future() {
     assert_eq!(
         client.verify_id_token(TOKEN).unwrap_err(),
         Error::InvalidToken(TokenValidationError::Claims(
-            FirebaseClaimsError::AuthenticatedInTheFuture
+            FirebaseClaimsError::AuthenticatedInTheFuture {
+                auth_time: 1607561874,
+                now: BEFORE_AUTHENTICATING
+            }
         ))
     );
 }
@@ -124,7 +130,10 @@ async fn expired_firebase_token_async() {
         .build();
     assert_eq!(
         client.verify_id_token(TOKEN).await.unwrap_err(),
-        Error::InvalidToken(TokenValidationError::Claims(FirebaseClaimsError::Expired))
+        Error::InvalidToken(TokenValidationError::Claims(FirebaseClaimsError::Expired {
+            now: AFTER_EXPIRATION,
+            exp: 1607565474
+        }))
     );
 }
 
@@ -139,7 +148,10 @@ async fn firebase_token_authenticated_in_the_future_async() {
     assert_eq!(
         client.verify_id_token(TOKEN).await.unwrap_err(),
         Error::InvalidToken(TokenValidationError::Claims(
-            FirebaseClaimsError::AuthenticatedInTheFuture
+            FirebaseClaimsError::AuthenticatedInTheFuture {
+                auth_time: 1607561874,
+                now: BEFORE_AUTHENTICATING
+            }
         ))
     );
 }

--- a/src/firebase_test.rs
+++ b/src/firebase_test.rs
@@ -1,0 +1,79 @@
+#[cfg(feature = "async")]
+use crate::key_provider::AsyncKeyProvider;
+#[cfg(feature = "blocking")]
+use crate::key_provider::KeyProvider;
+use crate::{
+    jwk::{JsonWebKey, JsonWebKeySet},
+    Client,
+};
+#[cfg(feature = "async")]
+use async_trait::async_trait;
+
+const TOKEN: &str = "eyJhbGciOiJSUzI1NiIsImtpZCI6ImI5ODI2ZDA5Mzc3N2NlMDA1ZTQzYTMyN2ZmMjAyNjUyMTQ1ZTk2MDQiLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJodHRwczovL3NlY3VyZXRva2VuLmdvb2dsZS5jb20vand0LXZlcmlmeSIsImF1ZCI6Imp3dC12ZXJpZnkiLCJhdXRoX3RpbWUiOjE2MDc1NjE4NzQsInVzZXJfaWQiOiJ0ZXN0Iiwic3ViIjoidGVzdCIsImlhdCI6MTYwNzU2MTg3NCwiZXhwIjoxNjA3NTY1NDc0LCJmaXJlYmFzZSI6eyJpZGVudGl0aWVzIjp7fSwic2lnbl9pbl9wcm92aWRlciI6ImN1c3RvbSJ9fQ.ZM6-sQXruuHoC5RJkhDfP5klTz9Rd0-8RQreydNqg7rIP1C-5BYG2R6y-Iq6OCrq6IrOtgvJ0QOJu9lnZpeks-InJB0ACTOLLpT-0Rj1zSSYm1KxtXsfrJu99gRKqY21W8405mDg7rp4S2LSqSWZnw1_zPt9YhLfvSWqqubHIomXh2AipvcjQVnn1AgV4vfIJ0yG3aq8Kw8li1k5ZVHmq5XaS2Gh4nP-fWnDzSxr9_AgYoiNlsncVuhGGo81IKNsXbwFuWRXYFuVffvGIhVfsiMAVCCwLjoM72RoAAikXCv3AfUWdklLOL2tcUkK42sLqUofHdqPAgtO4m8f9XGpgA";
+
+/// https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com at 2020/12/10 01:17 UTC
+const JWKS: &str = r#"{
+  "keys": [
+    {
+      "alg": "RS256",
+      "use": "sig",
+      "kid": "b9826d093777ce005e43a327ff202652145e9604",
+      "n": "57ATt2MoR9swEFVy6cCW_cbswo6UxQZn8knRPrkOPwm6RfopXl35osZVF2n18D2U62zeMDzgsoFMEWLYbP6kXn2OK2ABoIKz5DDVAmhXvElKy0pXLNPSyqQ4aJydorBoZJbugCCODPmdgmYp96vbZ7FHY3ZyFK00Lt8v49cbfGDZA50NoUcR3k0PbpiLVVaDxM34jTHr9U97hRyebnbbKTaoBI_crRzDL9yaWOpfBVpQv_5oXhhKUKzzJLOMMnkiMJ0VbM2iA8RbHNlmyRbY01Xhd0aEVBTDt56kFGzR3CXc1lYO0jfwYOdtfwNJ6eef-qg3i4Sog5vreMMJ2FCVyQ",
+      "e": "AQAB",
+      "kty": "RSA"
+    },
+    {
+      "e": "AQAB",
+      "alg": "RS256",
+      "kty": "RSA",
+      "n": "hsMFtQ6M-08j5LMBaCNp9FDNeNwuMNv4KwRo7BRTtUI-cjAtIJFgT57dLNsywu0IMArnhl0VlD7ChRFXs8x3vtRg10vQackII78-wD1zx8YRlNCLVLxDbDogOAMHIWhAYIcowSU8fOaMzQsJLnwu_ZT4BkJGwj01P59x2KufnDW9gxR52sp5otAfESYl7w3Ay49JZCPqpEoCv79M9lXOiEWzvcR9woxOw2L-PDDP0V4lMS3Wyw38zqNRuPVSdCWB15e_pAl3aSelV21pJBHvTPfrPJ9Ok3TBybXx_-yq4TEKYSZTmzYoKOT81T4pD4C4uejaQy_6liq2oua-N-gUlw",
+      "kid": "696aa74c81be60b294855a9a5ee9b8698e2abec1",
+      "use": "sig"
+    }
+  ]
+}"#;
+
+const PROJECT_ID: &str = "jwt-verify";
+
+#[derive(Default)]
+struct TestProvider;
+
+#[cfg(feature = "blocking")]
+impl KeyProvider for TestProvider {
+    fn get_key(&mut self, key_id: &str) -> Result<Option<JsonWebKey>, ()> {
+        let set: JsonWebKeySet = serde_json::from_str(JWKS).unwrap();
+        Ok(set.get_key(key_id))
+    }
+}
+
+#[cfg(feature = "async")]
+#[async_trait]
+impl AsyncKeyProvider for TestProvider {
+    async fn get_key_async(&mut self, key_id: &str) -> Result<Option<JsonWebKey>, ()> {
+        let set: JsonWebKeySet = serde_json::from_str(JWKS).unwrap();
+        Ok(set.get_key(key_id))
+    }
+}
+
+#[cfg(feature = "blocking")]
+#[test]
+fn valid_firebase_token() {
+    let client = Client::firebase_builder(PROJECT_ID)
+        .custom_key_provider(TestProvider)
+        .unsafe_mock_timestamp(1607562079)
+        .build();
+    let id_token = client.verify_id_token(TOKEN).unwrap();
+    assert_eq!(id_token.get_claims().get_subject(), "test");
+}
+
+#[cfg(feature = "async")]
+#[tokio::test]
+async fn valid_firebase_token_async() {
+    let client = Client::firebase_builder(PROJECT_ID)
+        .custom_key_provider(TestProvider)
+        .unsafe_mock_timestamp(1607562079)
+        .tokio()
+        .build();
+    let id_token = client.verify_id_token(TOKEN).await.unwrap();
+    assert_eq!(id_token.get_claims().get_subject(), "test");
+}

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -18,7 +18,7 @@ impl JsonWebKeySet {
     }
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Debug)]
 pub struct JsonWebKey {
     #[serde(rename = "alg")]
     algorithm: Algorithm,

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -7,7 +7,7 @@ use openssl::rsa::Rsa;
 use openssl::sign::Verifier;
 use serde_derive::Deserialize;
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Debug)]
 pub struct JsonWebKeySet {
     keys: Vec<JsonWebKey>,
 }

--- a/src/key_provider.rs
+++ b/src/key_provider.rs
@@ -108,7 +108,7 @@ impl Validator for FirebaseValidator {
 
 #[derive(Debug, Error, PartialEq)]
 pub enum FirebaseClaimsError {
-    #[error("JWT audience claim ({found}) is not equal to the project ID (expected)")]
+    #[error("JWT audience claim ({found}) is not equal to the project ID ({expected})")]
     InvalidAudience { found: String, expected: String },
     #[error("JWT issuer ({found}) is not equal to {expected}")]
     InvalidIssuer { found: String, expected: String },

--- a/src/key_provider.rs
+++ b/src/key_provider.rs
@@ -74,7 +74,7 @@ impl Validator for GoogleSigninValidator {
 
 impl TokenClaimsError for GoogleSigninClaimsError {}
 
-#[derive(Default)]
+#[derive(Default, Clone, Debug)]
 pub struct FirebaseAuthenticationKeyProvider {
     cache: Option<(JsonWebKeySet, Instant)>,
 }
@@ -87,6 +87,7 @@ impl FirebaseValidator {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct FirebaseValidator {
     project_id: String,
 }

--- a/src/key_provider.rs
+++ b/src/key_provider.rs
@@ -104,7 +104,7 @@ impl Validator for FirebaseValidator {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum FirebaseClaimsError {
     InvalidAudience,
     InvalidIssuer,

--- a/src/key_provider.rs
+++ b/src/key_provider.rs
@@ -104,6 +104,7 @@ impl Validator for FirebaseValidator {
     }
 }
 
+#[derive(Debug)]
 pub enum FirebaseClaimsError {
     InvalidAudience,
     InvalidIssuer,

--- a/src/key_provider.rs
+++ b/src/key_provider.rs
@@ -1,12 +1,17 @@
-use crate::jwk::JsonWebKey;
 use crate::jwk::JsonWebKeySet;
+use crate::{
+    jwk::JsonWebKey,
+    token::{
+        FirebaseIdPayload, FirebaseRequiredClaims, GoogleSigninIdPayload,
+        GoogleSigninRequiredClaims,
+    },
+    validator::Validator,
+};
 #[cfg(feature = "async")]
 use async_trait::async_trait;
 use headers::{Header, HeaderMap};
 use reqwest::header::CACHE_CONTROL;
 use std::time::Instant;
-
-const GOOGLE_CERT_URL: &str = "https://www.googleapis.com/oauth2/v3/certs";
 
 #[cfg(feature = "blocking")]
 pub trait KeyProvider {
@@ -19,100 +24,180 @@ pub trait AsyncKeyProvider {
     async fn get_key_async(&mut self, key_id: &str) -> Result<Option<JsonWebKey>, ()>;
 }
 
-pub struct GoogleKeyProvider {
-    cached: Option<JsonWebKeySet>,
-    expiration_time: Instant,
-    certificate_url: &'static str,
+#[derive(Default)]
+pub struct GoogleSigninKeyProvider {
+    cache: Option<(JsonWebKeySet, Instant)>,
 }
 
-impl Default for GoogleKeyProvider {
-    fn default() -> Self {
+pub struct GoogleSigninValidator {
+    client_id: String,
+}
+
+impl GoogleSigninValidator {
+    pub fn with_client_id(client_id: &str) -> Self {
         Self {
-            cached: None,
-            expiration_time: Instant::now(),
-            certificate_url: GOOGLE_CERT_URL,
+            client_id: client_id.into(),
         }
     }
 }
 
-impl GoogleKeyProvider {
-    pub fn with_certificate_url(certificate_url: &'static str) -> Self {
-        Self {
-            cached: None,
-            expiration_time: Instant::now(),
-            certificate_url,
-        }
-    }
-    fn process_response(&mut self, headers: &HeaderMap, text: &str) -> Result<&JsonWebKeySet, ()> {
-        let mut expiration_time = None;
-        let x = headers.get_all(CACHE_CONTROL);
-        if let Ok(cache_header) = headers::CacheControl::decode(&mut x.iter()) {
-            if let Some(max_age) = cache_header.max_age() {
-                expiration_time = Some(Instant::now() + max_age);
+impl GoogleKeyProvider for GoogleSigninKeyProvider {
+    fn valid_cache(&self) -> Option<&JsonWebKeySet> {
+        self.cache.as_ref().and_then(|(cache, expiration)| {
+            if expiration > &Instant::now() {
+                Some(cache)
+            } else {
+                None
             }
+        })
+    }
+    fn update_cache(&mut self, key_set: JsonWebKeySet, expiration: Instant) {
+        self.cache = Some((key_set, expiration));
+    }
+    fn certificate_url() -> &'static str {
+        "https://www.googleapis.com/oauth2/v3/certs"
+    }
+}
+
+impl Validator for GoogleSigninValidator {
+    type RequiredClaims = GoogleSigninRequiredClaims;
+    type IdPayload = GoogleSigninIdPayload;
+    fn claims_are_valid(&self, claims: &Self::RequiredClaims) -> bool {
+        claims.valid_for_client(&self.client_id)
+    }
+}
+
+#[derive(Default)]
+pub struct FirebaseAuthenticationKeyProvider {
+    cache: Option<(JsonWebKeySet, Instant)>,
+}
+
+impl FirebaseValidator {
+    pub fn with_project_id(project_id: &str) -> Self {
+        Self {
+            project_id: project_id.into(),
         }
-        let key_set = serde_json::from_str(&text).map_err(|_| ())?;
-        if let Some(expiration_time) = expiration_time {
-            self.cached = Some(key_set);
-            self.expiration_time = expiration_time;
+    }
+}
+
+pub struct FirebaseValidator {
+    project_id: String,
+}
+
+impl Validator for FirebaseValidator {
+    type RequiredClaims = FirebaseRequiredClaims;
+    type IdPayload = FirebaseIdPayload;
+    fn claims_are_valid(&self, claims: &Self::RequiredClaims) -> bool {
+        claims.valid_for_project(&self.project_id)
+    }
+}
+
+impl GoogleKeyProvider for FirebaseAuthenticationKeyProvider {
+    fn valid_cache(&self) -> Option<&JsonWebKeySet> {
+        self.cache.as_ref().and_then(|(cache, expiration)| {
+            if expiration > &Instant::now() {
+                Some(cache)
+            } else {
+                None
+            }
+        })
+    }
+    fn update_cache(&mut self, key_set: JsonWebKeySet, expiration: Instant) {
+        self.cache = Some((key_set, expiration));
+    }
+    fn certificate_url() -> &'static str {
+        "https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com"
+    }
+}
+
+pub trait GoogleKeyProvider: Default {
+    fn valid_cache(&self) -> Option<&JsonWebKeySet>;
+    fn update_cache(&mut self, key_set: JsonWebKeySet, expiration: Instant);
+    fn certificate_url() -> &'static str;
+}
+
+fn process_response<'a>(
+    key_provider: &'a mut impl GoogleKeyProvider,
+    headers: &HeaderMap,
+    text: &str,
+) -> Option<&'a JsonWebKeySet> {
+    let x = headers.get_all(CACHE_CONTROL);
+    if let (Ok(cache_header), Ok(key_set)) = (
+        headers::CacheControl::decode(&mut x.iter()),
+        serde_json::from_str(&text),
+    ) {
+        if let Some(max_age) = cache_header.max_age() {
+            let expiration = Instant::now() + max_age;
+            key_provider.update_cache(key_set, expiration);
         }
-        Ok(self.cached.as_ref().unwrap())
     }
-    #[cfg(feature = "blocking")]
-    pub fn download_keys(&mut self) -> Result<&JsonWebKeySet, ()> {
-        let result = reqwest::blocking::get(self.certificate_url).map_err(|_| ())?;
-        self.process_response(&result.headers().clone(), &result.text().map_err(|_| ())?)
-    }
-    #[cfg(feature = "async")]
-    async fn download_keys_async(&mut self) -> Result<&JsonWebKeySet, ()> {
-        let result = reqwest::get(self.certificate_url).await.map_err(|_| ())?;
-        self.process_response(
-            &result.headers().clone(),
-            &result.text().await.map_err(|_| ())?,
-        )
-    }
+    key_provider.valid_cache()
 }
 
 #[cfg(feature = "blocking")]
-impl KeyProvider for GoogleKeyProvider {
+impl<T: GoogleKeyProvider> KeyProvider for T {
     fn get_key(&mut self, key_id: &str) -> Result<Option<JsonWebKey>, ()> {
-        if let Some(ref cached_keys) = self.cached {
-            if self.expiration_time > Instant::now() {
-                return Ok(cached_keys.get_key(key_id));
-            }
+        if let Some(key_set) = self.valid_cache() {
+            Ok(key_set.get_key(key_id))
+        } else {
+            let result = reqwest::blocking::get(T::certificate_url()).map_err(|_| ())?;
+            Ok(process_response(
+                self,
+                &result.headers().clone(),
+                &result.text().map_err(|_| ())?,
+            )
+            .and_then(|key_set| key_set.get_key(key_id)))
         }
-        Ok(self.download_keys()?.get_key(key_id))
     }
 }
 
 #[cfg(feature = "async")]
 #[async_trait]
-impl AsyncKeyProvider for GoogleKeyProvider {
+impl<T: GoogleKeyProvider + Send + Sync> AsyncKeyProvider for T {
     async fn get_key_async(&mut self, key_id: &str) -> Result<Option<JsonWebKey>, ()> {
-        if let Some(ref cached_keys) = self.cached {
-            if self.expiration_time > Instant::now() {
-                return Ok(cached_keys.get_key(key_id));
+        if let Some(key_set) = self.valid_cache() {
+            Ok(key_set.get_key(key_id))
+        } else {
+            let url = T::certificate_url();
+            if let Ok(response) = reqwest::get(url).await {
+                let headers = response.headers().clone();
+                if let Ok(text) = response.text().await {
+                    Ok(process_response(self, &headers, &text)
+                        .and_then(|key_set| key_set.get_key(key_id)))
+                } else {
+                    Err(())
+                }
+            } else {
+                Err(())
             }
         }
-        Ok(self.download_keys_async().await?.get_key(key_id))
     }
 }
 
 #[cfg(feature = "blocking")]
 #[test]
 pub fn test_google_provider() {
-    let mut provider = GoogleKeyProvider::default();
+    let mut provider = GoogleSigninKeyProvider::default();
+    assert!(provider.get_key("test").is_ok());
+    assert!(provider.get_key("test").is_ok());
+
+    let mut provider = FirebaseAuthenticationKeyProvider::default();
     assert!(provider.get_key("test").is_ok());
     assert!(provider.get_key("test").is_ok());
 }
 
 #[cfg(all(test, feature = "async"))]
 mod async_test {
-    use super::{AsyncKeyProvider, GoogleKeyProvider};
+    use super::AsyncKeyProvider;
+    use crate::key_provider::{FirebaseAuthenticationKeyProvider, GoogleSigninKeyProvider};
     use tokio;
     #[tokio::test]
     async fn test_google_provider_async() {
-        let mut provider = GoogleKeyProvider::default();
+        let mut provider = GoogleSigninKeyProvider::default();
+        assert!(provider.get_key_async("test").await.is_ok());
+        assert!(provider.get_key_async("test").await.is_ok());
+
+        let mut provider = FirebaseAuthenticationKeyProvider::default();
         assert!(provider.get_key_async("test").await.is_ok());
         assert!(provider.get_key_async("test").await.is_ok());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@ mod token;
 mod unverified_token;
 
 pub use crate::client::Client;
+#[cfg(feature = "async")]
+pub use crate::client::TokioClient;
 pub use crate::token::{IdPayload, RequiredClaims, Token};
 pub use error::Error;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 #[cfg(test)]
+mod firebase_test;
+#[cfg(test)]
 mod test;
 
 mod algorithm;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,11 @@ pub use crate::token::{
     GoogleSigninIdPayload as IdPayload, GoogleSigninRequiredClaims as RequiredClaims, Token,
 };
 pub use error::Error;
+use token::GoogleSigninClaimsError;
+use key_provider::FirebaseClaimsError;
+
+pub type FirebaseError = Error<FirebaseClaimsError>;
+pub type GoogleSigninError = Error<GoogleSigninClaimsError>;
 
 fn base64_decode(input: &str) -> Result<Vec<u8>, base64::DecodeError> {
     base64::decode_config(&input, base64::URL_SAFE)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,9 @@ mod token;
 mod unverified_token;
 mod validator;
 
-pub use crate::client::Client;
+pub use crate::client::{Client, FirebaseClient};
+#[cfg(feature = "async")]
+pub use crate::client::{FirebaseTokioClient, GoogleSigninTokioClient};
 pub use crate::token::{
     GoogleSigninIdPayload as IdPayload, GoogleSigninRequiredClaims as RequiredClaims, Token,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,12 @@
 mod test;
 
 mod algorithm;
-mod claims;
 mod client;
 mod error;
 mod header;
 mod jwk;
 mod key_provider;
+mod time;
 mod token;
 mod unverified_token;
 mod validator;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 mod test;
 
 mod algorithm;
+mod claims;
 mod client;
 mod error;
 mod header;
@@ -9,9 +10,12 @@ mod jwk;
 mod key_provider;
 mod token;
 mod unverified_token;
+mod validator;
 
 pub use crate::client::Client;
-pub use crate::token::{IdPayload, RequiredClaims, Token};
+pub use crate::token::{
+    GoogleSigninIdPayload as IdPayload, GoogleSigninRequiredClaims as RequiredClaims, Token,
+};
 pub use error::Error;
 
 fn base64_decode(input: &str) -> Result<Vec<u8>, base64::DecodeError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,8 @@ pub use crate::token::{
     GoogleSigninIdPayload as IdPayload, GoogleSigninRequiredClaims as RequiredClaims, Token,
 };
 pub use error::Error;
-use token::GoogleSigninClaimsError;
 use key_provider::FirebaseClaimsError;
+use token::GoogleSigninClaimsError;
 
 pub type FirebaseError = Error<FirebaseClaimsError>;
 pub type GoogleSigninError = Error<GoogleSigninClaimsError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,12 +18,15 @@ pub use crate::client::{Client, FirebaseClient};
 #[cfg(feature = "async")]
 pub use crate::client::{FirebaseTokioClient, GoogleSigninTokioClient};
 pub use crate::token::{
-    GoogleSigninIdPayload as IdPayload, GoogleSigninRequiredClaims as RequiredClaims, Token,
+    FirebaseIdPayload, FirebaseRequiredClaims, GoogleSigninIdPayload, GoogleSigninRequiredClaims,
+    Token,
 };
 pub use error::Error;
 use key_provider::FirebaseClaimsError;
 use token::GoogleSigninClaimsError;
 
+pub type IdPayload = GoogleSigninIdPayload;
+pub type RequiredClaims = GoogleSigninRequiredClaims;
 pub type FirebaseError = Error<FirebaseClaimsError>;
 pub type GoogleSigninError = Error<GoogleSigninClaimsError>;
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use super::*;
-use crate::{error::Error, client::GoogleSigninTokioClient};
+#[cfg(feature = "async")]
+use crate::client::GoogleSigninTokioClient;
+use crate::error::Error;
 use crate::jwk::JsonWebKey;
 use crate::jwk::JsonWebKeySet;
 #[cfg(feature = "async")]
@@ -124,12 +126,11 @@ async fn decode_keys_async() {
 #[cfg(feature = "async")]
 #[tokio::test]
 async fn test_client_async() {
-    let client = Client::builder(
-        "37772117408-qjqo9hca513pdcunumt7gk08ii6te8is.apps.googleusercontent.com",
-    )
-    .custom_key_provider(TestKeyProvider::default())
-    .tokio()
-    .build();
+    let client =
+        Client::builder("37772117408-qjqo9hca513pdcunumt7gk08ii6te8is.apps.googleusercontent.com")
+            .custom_key_provider(TestKeyProvider::default())
+            .tokio()
+            .build();
     assert_eq!(
         client.verify_token(TOKEN).await.map(|_| ()),
         Err(Error::Expired)

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
 use super::*;
+#[cfg(feature = "async")]
+use crate::client::GoogleSigninTokioClient;
 use crate::error::Error;
 use crate::jwk::JsonWebKey;
 use crate::jwk::JsonWebKeySet;
@@ -8,10 +10,7 @@ use crate::jwk::JsonWebKeySet;
 use crate::key_provider::AsyncKeyProvider;
 #[cfg(feature = "blocking")]
 use crate::key_provider::KeyProvider;
-#[cfg(feature = "async")]
-use crate::{
-    client::GoogleSigninTokioClient, error::TokenValidationError, token::GoogleSigninClaimsError,
-};
+use crate::{error::TokenValidationError, token::GoogleSigninClaimsError};
 #[cfg(feature = "async")]
 use futures::future::join_all;
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,4 +1,8 @@
+use std::sync::Arc;
+
 use super::*;
+#[cfg(feature = "async")]
+use crate::client::TokioClient;
 use crate::error::Error;
 use crate::jwk::JsonWebKey;
 use crate::jwk::JsonWebKeySet;
@@ -6,6 +10,8 @@ use crate::jwk::JsonWebKeySet;
 use crate::key_provider::AsyncKeyProvider;
 #[cfg(feature = "blocking")]
 use crate::key_provider::KeyProvider;
+#[cfg(feature = "async")]
+use futures::future::join_all;
 
 #[cfg(feature = "async")]
 use async_trait::async_trait;
@@ -34,12 +40,16 @@ const JWKS: &'static str = r#"{
 const AUDIENCE: &'static str =
     "37772117408-qjqo9hca513pdcunumt7gk08ii6te8is.apps.googleusercontent.com";
 
-struct TestKeyProvider;
+#[derive(Default)]
+struct TestKeyProvider {
+    call_count: Arc<std::sync::RwLock<u8>>,
+}
 
 #[cfg(feature = "blocking")]
 impl KeyProvider for TestKeyProvider {
     fn get_key(&mut self, key_id: &str) -> Result<Option<JsonWebKey>, ()> {
         let set: JsonWebKeySet = serde_json::from_str(JWKS).unwrap();
+        *self.call_count.write().unwrap() += 1;
         Ok(set.get_key(key_id))
     }
 }
@@ -49,6 +59,7 @@ impl KeyProvider for TestKeyProvider {
 impl AsyncKeyProvider for TestKeyProvider {
     async fn get_key_async(&mut self, key_id: &str) -> Result<Option<JsonWebKey>, ()> {
         let set: JsonWebKeySet = serde_json::from_str(JWKS).unwrap();
+        *self.call_count.write().unwrap() += 1;
         Ok(set.get_key(key_id))
     }
 }
@@ -56,10 +67,10 @@ impl AsyncKeyProvider for TestKeyProvider {
 #[cfg(feature = "blocking")]
 #[test]
 pub fn decode_keys() {
-    TestKeyProvider
+    TestKeyProvider::default()
         .get_key("3f3ef9c7803cd0b8d75247ee0d31fdd5c2cf3812")
         .unwrap();
-    TestKeyProvider
+    TestKeyProvider::default()
         .get_key("a748e9f767159f667a0223318de0b2329e544362")
         .unwrap();
 }
@@ -69,7 +80,7 @@ pub fn decode_keys() {
 pub fn test_client() {
     let client =
         Client::builder("37772117408-qjqo9hca513pdcunumt7gk08ii6te8is.apps.googleusercontent.com")
-            .custom_key_provider(TestKeyProvider)
+            .custom_key_provider(TestKeyProvider::default())
             .build();
     assert_eq!(client.verify_token(TOKEN).map(|_| ()), Err(Error::Expired));
 }
@@ -78,7 +89,7 @@ pub fn test_client() {
 #[test]
 pub fn test_client_invalid_client_id() {
     let client = Client::builder("invalid client id")
-        .custom_key_provider(TestKeyProvider)
+        .custom_key_provider(TestKeyProvider::default())
         .build();
     let result = client.verify_token(TOKEN).map(|_| ());
     assert_eq!(result, Err(Error::InvalidToken))
@@ -88,7 +99,7 @@ pub fn test_client_invalid_client_id() {
 #[test]
 pub fn test_id_token() {
     let client = Client::builder(AUDIENCE)
-        .custom_key_provider(TestKeyProvider)
+        .custom_key_provider(TestKeyProvider::default())
         .unsafe_ignore_expiration()
         .build();
     let id_token = client
@@ -102,11 +113,11 @@ pub fn test_id_token() {
 #[cfg(feature = "async")]
 #[tokio::test]
 async fn decode_keys_async() {
-    TestKeyProvider
+    TestKeyProvider::default()
         .get_key_async("3f3ef9c7803cd0b8d75247ee0d31fdd5c2cf3812")
         .await
         .unwrap();
-    TestKeyProvider
+    TestKeyProvider::default()
         .get_key_async("a748e9f767159f667a0223318de0b2329e544362")
         .await
         .unwrap();
@@ -115,10 +126,11 @@ async fn decode_keys_async() {
 #[cfg(feature = "async")]
 #[tokio::test]
 async fn test_client_async() {
-    let client =
-        Client::builder("37772117408-qjqo9hca513pdcunumt7gk08ii6te8is.apps.googleusercontent.com")
-            .custom_key_provider(TestKeyProvider)
-            .build();
+    let client = TokioClient::builder(
+        "37772117408-qjqo9hca513pdcunumt7gk08ii6te8is.apps.googleusercontent.com",
+    )
+    .custom_key_provider(TestKeyProvider::default())
+    .build();
     assert_eq!(
         client.verify_token_async(TOKEN).await.map(|_| ()),
         Err(Error::Expired)
@@ -128,8 +140,8 @@ async fn test_client_async() {
 #[cfg(feature = "async")]
 #[tokio::test]
 async fn test_client_invalid_client_id_async() {
-    let client = Client::builder("invalid client id")
-        .custom_key_provider(TestKeyProvider)
+    let client = TokioClient::builder("invalid client id")
+        .custom_key_provider(TestKeyProvider::default())
         .build();
     let result = client.verify_token_async(TOKEN).await.map(|_| ());
     assert_eq!(result, Err(Error::InvalidToken))
@@ -138,8 +150,8 @@ async fn test_client_invalid_client_id_async() {
 #[cfg(feature = "async")]
 #[tokio::test]
 async fn test_id_token_async() {
-    let client = Client::builder(AUDIENCE)
-        .custom_key_provider(TestKeyProvider)
+    let client = TokioClient::builder(AUDIENCE)
+        .custom_key_provider(TestKeyProvider::default())
         .unsafe_ignore_expiration()
         .build();
     let id_token = client
@@ -149,4 +161,19 @@ async fn test_id_token_async() {
     assert_eq!(id_token.get_claims().get_audience(), AUDIENCE);
     assert_eq!(id_token.get_payload().get_domain(), None);
     assert_eq!(id_token.get_payload().get_email(), "fuchsnj@gmail.com");
+}
+
+#[cfg(feature = "async")]
+#[tokio::test]
+async fn test_deadlock_prevention() {
+    let client = TokioClient::builder(AUDIENCE)
+        .unsafe_ignore_expiration()
+        .build();
+    join_all((0..10u8).map(|_| verify_token_async(&client))).await;
+}
+
+#[cfg(feature = "async")]
+async fn verify_token_async(client: &TokioClient) {
+    let result = client.verify_token_async(TOKEN).await;
+    assert_eq!(result, Err(Error::InvalidToken));
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,11 +1,11 @@
 use super::*;
-use crate::error::Error;
 use crate::jwk::JsonWebKey;
 use crate::jwk::JsonWebKeySet;
 #[cfg(feature = "async")]
 use crate::key_provider::AsyncKeyProvider;
 #[cfg(feature = "blocking")]
 use crate::key_provider::KeyProvider;
+use crate::error::Error;
 
 #[cfg(feature = "async")]
 use async_trait::async_trait;

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,7 @@
+use std::time::{SystemTime, SystemTimeError, UNIX_EPOCH};
+
+pub fn current_timestamp() -> Result<u64, SystemTimeError> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+}

--- a/src/token.rs
+++ b/src/token.rs
@@ -162,7 +162,7 @@ impl GoogleSigninRequiredClaims {
 
 #[derive(Debug, Error, PartialEq)]
 pub enum GoogleSigninClaimsError {
-    #[error("JWT audience claim ({found}) is not equal to the client ID (expected)")]
+    #[error("JWT audience claim ({found}) is not equal to the client ID ({expected})")]
     InvalidAudience { found: String, expected: String },
     #[error("JWT issuer ({found}) is neither {} nor {}", .allowed[0], .allowed[1])]
     InvalidIssuer {

--- a/src/token.rs
+++ b/src/token.rs
@@ -137,9 +137,9 @@ pub enum GoogleSigninClaimsError {
     IssuedAfterExpiry,
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Debug)]
 pub struct FirebaseIdPayload {
-    name: String,
+    name: Option<String>,
 }
 
 #[derive(Deserialize, Clone, Debug, PartialEq)]

--- a/src/token.rs
+++ b/src/token.rs
@@ -48,6 +48,9 @@ impl FirebaseRequiredClaims {
         self.audience == project_id
             && self.issuer == format!("https://securetoken.google.com/{}", project_id)
     }
+    pub fn get_subject(&self) -> String {
+        self.subject.clone()
+    }
 }
 
 impl Claims for FirebaseRequiredClaims {
@@ -56,9 +59,6 @@ impl Claims for FirebaseRequiredClaims {
     }
     fn get_expires_at(&self) -> u64 {
         self.expires_at
-    }
-    fn get_subject(&self) -> &str {
-        self.subject.as_str()
     }
 }
 
@@ -115,9 +115,6 @@ impl Claims for GoogleSigninRequiredClaims {
     }
     fn get_expires_at(&self) -> u64 {
         self.expires_at
-    }
-    fn get_subject(&self) -> &str {
-        self.subject.as_str()
     }
 }
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,5 +1,5 @@
-use serde_derive::Deserialize;
 use crate::claims::Claims;
+use serde_derive::Deserialize;
 
 #[derive(Debug, PartialEq)]
 pub struct Token<P, C> {

--- a/src/token.rs
+++ b/src/token.rs
@@ -144,6 +144,7 @@ pub struct FirebaseIdPayload {
     email_verified: Option<bool>,
     phone_number: Option<String>,
     picture: Option<String>,
+    sub: String,
 }
 
 impl FirebaseIdPayload {
@@ -161,6 +162,9 @@ impl FirebaseIdPayload {
     }
     pub fn get_picture(&self) -> &Option<String> {
         &self.picture
+    }
+    pub fn get_user_id(&self) -> &String {
+        &self.sub
     }
 }
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -143,14 +143,14 @@ pub struct FirebaseIdPayload {
     email: Option<String>,
     email_verified: Option<bool>,
     phone_number: Option<String>,
-    picture: Option<String>
+    picture: Option<String>,
 }
 
 impl FirebaseIdPayload {
     pub fn get_name(&self) -> &Option<String> {
         &self.name
     }
-    pub fn get_email(&self) -> &Option<String>{
+    pub fn get_email(&self) -> &Option<String> {
         &self.email
     }
     pub fn is_email_verified(&self) -> Option<bool> {

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,5 +1,6 @@
 use serde_derive::Deserialize;
 
+#[derive(Debug, PartialEq)]
 pub struct Token<P> {
     required_claims: RequiredClaims,
     payload: P,
@@ -20,7 +21,7 @@ impl<P> Token<P> {
     }
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(PartialEq, Deserialize, Debug, Clone)]
 pub struct RequiredClaims {
     #[serde(rename = "iss")]
     issuer: String,

--- a/src/token.rs
+++ b/src/token.rs
@@ -21,6 +21,9 @@ impl<P, C: Clone> Token<P, C> {
     pub fn get_payload(&self) -> &P {
         &self.payload
     }
+    pub fn move_payload(self) -> P {
+        self.payload
+    }
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/src/token.rs
+++ b/src/token.rs
@@ -140,6 +140,28 @@ pub enum GoogleSigninClaimsError {
 #[derive(Deserialize, Clone, Debug)]
 pub struct FirebaseIdPayload {
     name: Option<String>,
+    email: Option<String>,
+    email_verified: Option<bool>,
+    phone_number: Option<String>,
+    picture: Option<String>
+}
+
+impl FirebaseIdPayload {
+    pub fn get_name(&self) -> &Option<String> {
+        &self.name
+    }
+    pub fn get_email(&self) -> &Option<String>{
+        &self.email
+    }
+    pub fn is_email_verified(&self) -> Option<bool> {
+        self.email_verified
+    }
+    pub fn get_phone_number(&self) -> &Option<String> {
+        &self.phone_number
+    }
+    pub fn get_picture(&self) -> &Option<String> {
+        &self.picture
+    }
 }
 
 #[derive(Deserialize, Clone, Debug, PartialEq)]

--- a/src/unverified_token.rs
+++ b/src/unverified_token.rs
@@ -1,6 +1,6 @@
-use std::sync::Arc;
 #[cfg(feature = "blocking")]
 use std::sync::Mutex;
+use std::{fmt::Debug, sync::Arc};
 
 use serde::Deserialize;
 
@@ -14,6 +14,7 @@ use crate::{
     error::{JsonDeserializationError, TokenValidationError},
 };
 
+#[derive(Debug)]
 pub struct UnverifiedToken<P, C> {
     header: Header,
     signed_body: String,
@@ -25,7 +26,7 @@ pub struct UnverifiedToken<P, C> {
 impl<P, C> UnverifiedToken<P, C>
 where
     for<'a> P: Deserialize<'a>,
-    for<'a> C: Deserialize<'a> + Clone,
+    for<'a> C: Deserialize<'a> + Clone + Debug,
 {
     pub fn validate<V>(
         token_string: &str,
@@ -72,7 +73,7 @@ where
 
 impl<P, C> UnverifiedToken<P, C>
 where
-    C: Clone + for<'a> Deserialize<'a>,
+    C: Clone + for<'a> Deserialize<'a> + Debug,
 {
     #[cfg(feature = "blocking")]
     pub fn verify<KP: KeyProvider, V: Validator<RequiredClaims = C>>(

--- a/src/unverified_token.rs
+++ b/src/unverified_token.rs
@@ -100,7 +100,11 @@ where
             Ok(None) => return Err(Error::KeyDoesNotExist),
             Err(_) => return Err(Error::RetrieveKeyFailure),
         };
-        key.verify(self.signed_body.as_bytes(), &self.signature)?;
+        key.verify(self.signed_body.as_bytes(), &self.signature)
+            .map_err(|e| Error::Verification {
+                kid: key.get_id(),
+                source: e.into(),
+            })?;
         Ok(Token::new(self.claims, self.json_payload))
     }
 }

--- a/src/unverified_token.rs
+++ b/src/unverified_token.rs
@@ -75,10 +75,10 @@ impl<P> UnverifiedToken<P> {
     #[cfg(feature = "async")]
     pub async fn verify_async<KP: AsyncKeyProvider>(
         self,
-        key_provider: &Arc<Mutex<KP>>,
+        key_provider: &Arc<tokio::sync::Mutex<KP>>,
     ) -> Result<Token<P>, Error> {
         let key_id = self.header.key_id.clone();
-        self.verify_with_key(key_provider.lock().unwrap().get_key_async(&key_id).await)
+        self.verify_with_key(key_provider.lock().await.get_key_async(&key_id).await)
     }
     fn verify_with_key(self, key: Result<Option<JsonWebKey>, ()>) -> Result<Token<P>, Error> {
         let key = match key {

--- a/src/unverified_token.rs
+++ b/src/unverified_token.rs
@@ -1,9 +1,9 @@
+#[cfg(feature = "blocking")]
+use std::sync::Mutex;
 use std::{
     sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
-#[cfg(feature = "blocking")]
-use std::sync::Mutex;
 
 use serde::Deserialize;
 

--- a/src/unverified_token.rs
+++ b/src/unverified_token.rs
@@ -1,7 +1,9 @@
 use std::{
-    sync::{Arc, Mutex},
+    sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
+#[cfg(feature = "blocking")]
+use std::sync::Mutex;
 
 use serde::Deserialize;
 

--- a/src/unverified_token.rs
+++ b/src/unverified_token.rs
@@ -10,25 +10,26 @@ use crate::key_provider::AsyncKeyProvider;
 #[cfg(feature = "blocking")]
 use crate::key_provider::KeyProvider;
 use crate::{
-    base64_decode, client::Kind, header::Header, jwk::JsonWebKey, Error, RequiredClaims, Token,
+    base64_decode, claims::Claims, header::Header, jwk::JsonWebKey, validator::Validator, Error,
+    Token,
 };
 
-pub struct UnverifiedToken<P> {
+pub struct UnverifiedToken<P, C> {
     header: Header,
     signed_body: String,
     signature: Vec<u8>,
-    claims: RequiredClaims,
+    claims: C,
     json_payload: P,
 }
 
-impl<P> UnverifiedToken<P>
+impl<P, C: Claims> UnverifiedToken<P, C>
 where
     for<'a> P: Deserialize<'a>,
 {
-    pub fn validate(
+    pub fn validate<V: Validator<RequiredClaims = C>>(
         token_string: &str,
         check_expiration: bool,
-        client_kind: &Kind,
+        validator: &V,
     ) -> Result<Self, Error> {
         let mut segments = token_string.split('.');
         let encoded_header = segments.next().ok_or(Error::InvalidToken)?;
@@ -39,12 +40,8 @@ where
         let signed_body = format!("{}.{}", encoded_header, encoded_payload);
         let signature = base64_decode(&encoded_signature)?;
         let payload = base64_decode(&encoded_payload)?;
-        let claims: RequiredClaims = serde_json::from_slice(&payload)?;
-        if claims.get_audience() != client_kind.valid_audience() {
-            return Err(Error::InvalidToken);
-        }
-        let issuer = claims.get_issuer();
-        if !client_kind.valid_issuers().contains(&issuer) {
+        let claims: V::RequiredClaims = serde_json::from_slice(&payload)?;
+        if !validator.claims_are_valid(&claims) {
             return Err(Error::InvalidToken);
         }
         let current_timestamp = SystemTime::now()
@@ -68,9 +65,12 @@ where
     }
 }
 
-impl<P> UnverifiedToken<P> {
+impl<P, C: Clone> UnverifiedToken<P, C> {
     #[cfg(feature = "blocking")]
-    pub fn verify<KP: KeyProvider>(self, key_provider: &Arc<Mutex<KP>>) -> Result<Token<P>, Error> {
+    pub fn verify<KP: KeyProvider>(
+        self,
+        key_provider: &Arc<Mutex<KP>>,
+    ) -> Result<Token<P, C>, Error> {
         let key_id = self.header.key_id.clone();
         self.verify_with_key(key_provider.lock().unwrap().get_key(&key_id))
     }
@@ -78,11 +78,11 @@ impl<P> UnverifiedToken<P> {
     pub async fn verify_async<KP: AsyncKeyProvider>(
         self,
         key_provider: &Arc<Mutex<KP>>,
-    ) -> Result<Token<P>, Error> {
+    ) -> Result<Token<P, C>, Error> {
         let key_id = self.header.key_id.clone();
         self.verify_with_key(key_provider.lock().unwrap().get_key_async(&key_id).await)
     }
-    fn verify_with_key(self, key: Result<Option<JsonWebKey>, ()>) -> Result<Token<P>, Error> {
+    fn verify_with_key(self, key: Result<Option<JsonWebKey>, ()>) -> Result<Token<P, C>, Error> {
         let key = match key {
             Ok(Some(key)) => key,
             Ok(None) => return Err(Error::InvalidToken),

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1,10 +1,12 @@
+use std::fmt::Debug;
+
 use serde::Deserialize;
 
 use crate::error::TokenClaimsError;
 
 pub trait Validator {
-    type RequiredClaims: for<'a> Deserialize<'a> + Clone;
-    type IdPayload: for<'a> Deserialize<'a>;
+    type RequiredClaims: for<'a> Deserialize<'a> + Clone + Debug;
+    type IdPayload: for<'a> Deserialize<'a> + Debug;
     type ClaimsError: TokenClaimsError;
     fn validate_claims(
         &self,

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1,9 +1,14 @@
 use serde::Deserialize;
 
-use crate::claims::Claims;
+use crate::error::TokenClaimsError;
 
 pub trait Validator {
-    type RequiredClaims: Claims;
+    type RequiredClaims: for<'a> Deserialize<'a> + Clone;
     type IdPayload: for<'a> Deserialize<'a>;
-    fn claims_are_valid(&self, claims: &Self::RequiredClaims) -> bool;
+    type ClaimsError: TokenClaimsError;
+    fn validate_claims(
+        &self,
+        claims: &Self::RequiredClaims,
+        current_timestamp: u64,
+    ) -> Result<(), Self::ClaimsError>;
 }

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1,0 +1,9 @@
+use serde::Deserialize;
+
+use crate::claims::Claims;
+
+pub trait Validator {
+    type RequiredClaims: Claims;
+    type IdPayload: for<'a> Deserialize<'a>;
+    fn claims_are_valid(&self, claims: &Self::RequiredClaims) -> bool;
+}


### PR DESCRIPTION
Closes #8

Usage

with `blocking` feature
```rust
let client = Client::new_firebase("project_id");
let id_token = client.verify_id_token("token").unwrap();
```
with `async` feature
```rust
let client = Client::firebase_builder("project_id").tokio().build();
let id_token = client.verify_id_token("token").await.unwrap();
```

Progress

- [x] Generalise `GoogleKeyProvider` to support both Google Signin and Firebase Authentication
- [x] Specialise `RequiredClaims` for Google Signin and Firebase Authentication 
- [x]  Specialise `IdPayload` for Google Signin and Firebase Authentication 
- [x] Expose new API to verify firebase tokens
- [x] Check that `auth_time` claim is in the past for firebase tokens
- [x] Expand `FirebaseIdPayload` to cover most of firebase token payload schema
- [x] Unit test `FirebaseClient` using custom key provider
- [ ] Refactor files

