### PR TITLE
Prevent deadlock by using tokio::sync::Mutex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default = ["blocking", "native-ssl"]
 async = ["async-trait", "tokio"]
 blocking = ["reqwest/blocking"]
 native-ssl = ["reqwest/default", "dep:openssl"]
-rust-ssl = ["reqwest/rustls-tls-native-roots", "dep:rsa", "dep:sha2"]
+rust-ssl = ["reqwest/rustls-tls-native-roots", "dep:ring"]
 
 [dependencies]
 async-trait = {version = "~0.1", optional = true}
@@ -28,8 +28,7 @@ reqwest = { version = "0.11.26", default-features = false }
 http = "0.2" # reqwest 0.11.26 uses this version
 cache_control = "~0.2"
 tokio = {version = "1", optional = true}
-rsa = { version = "0.9.6", optional = true }
-sha2 = { version = "0.10.8", features = ["oid"], optional = true }
+ring = { version = "=0.17.8", optional = true }
 
 [dev-dependencies]
 tokio = {version = "1", features = ["macros"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [features]
 default = ["blocking"]
-async = ["async-trait"]
+async = ["async-trait", "tokio"]
 blocking = ["reqwest/blocking"]
 
 [dependencies]
@@ -24,6 +24,8 @@ serde_json = "1.0.48"
 serde_derive = "1.0.104"
 reqwest = {version="0.10.4"}
 headers = "0.3.1"
+tokio = {version = "0.2", optional = true}
 
 [dev-dependencies]
 tokio = {version = "0.2", features = ["macros"]}
+futures = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,21 +11,25 @@ A client to verify Google JSON web tokens
 edition = "2021"
 
 [features]
-default = ["blocking"]
+default = ["blocking", "native-ssl"]
 async = ["async-trait", "tokio"]
 blocking = ["reqwest/blocking"]
+native-ssl = ["reqwest/default", "dep:openssl"]
+rust-ssl = ["reqwest/rustls-tls-native-roots", "dep:rsa", "dep:sha2"]
 
 [dependencies]
 async-trait = {version = "~0.1", optional = true}
-openssl = "~0.10"
+openssl = { version = "~0.10", optional = true }
 base64 = "~0.22"
 serde = "~1.0"
 serde_json = "~1.0"
 serde_derive = "~1.0"
-reqwest = "0.11.26"
+reqwest = { version = "0.11.26", default-features = false }
 http = "0.2" # reqwest 0.11.26 uses this version
 cache_control = "~0.2"
 tokio = {version = "1", optional = true}
+rsa = { version = "0.9.6", optional = true }
+sha2 = { version = "0.10.8", features = ["oid"], optional = true }
 
 [dev-dependencies]
 tokio = {version = "1", features = ["macros"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT/Apache-2.0"
 description = """
 A client to verify Google JSON web tokens
 """
-edition = "2018"
+edition = "2021"
 
 [features]
 default = ["blocking"]
@@ -16,16 +16,17 @@ async = ["async-trait", "tokio"]
 blocking = ["reqwest/blocking"]
 
 [dependencies]
-async-trait = {version = "0.1.42", optional = true}
-openssl = "0.10.28"
-base64 = "0.11.0"
-serde = "1.0.104"
-serde_json = "1.0.48"
-serde_derive = "1.0.104"
-reqwest = {version="0.10.4"}
-headers = "0.3.1"
-tokio = {version = "0.2", optional = true}
+async-trait = {version = "~0.1", optional = true}
+openssl = "~0.10"
+base64 = "~0.22"
+serde = "~1.0"
+serde_json = "~1.0"
+serde_derive = "~1.0"
+reqwest = "0.11.26"
+http = "0.2" # reqwest 0.11.26 uses this version
+cache_control = "~0.2"
+tokio = {version = "1", optional = true}
 
 [dev-dependencies]
-tokio = {version = "0.2", features = ["macros"]}
+tokio = {version = "1", features = ["macros"]}
 futures = "0.3"

--- a/src/client.rs
+++ b/src/client.rs
@@ -103,7 +103,7 @@ impl<KP: Default> GenericClient<Arc<tokio::sync::Mutex<KP>>> {
 impl<KP: KeyProvider> GenericClient<Arc<Mutex<KP>>> {
     pub fn verify_token_with_payload<P>(&self, token_string: &str) -> Result<Token<P>, Error>
     where
-        for<'a> P: Deserialize<'a>,
+        for<'a> P: Deserialize<'a> + std::fmt::Debug,
     {
         let unverified_token =
             UnverifiedToken::<P>::validate(token_string, self.check_expiration, &self.client_id)?;
@@ -126,7 +126,7 @@ impl<KP: AsyncKeyProvider> GenericClient<Arc<tokio::sync::Mutex<KP>>> {
         token_string: &str,
     ) -> Result<Token<P>, Error>
     where
-        for<'a> P: Deserialize<'a>,
+        for<'a> P: Deserialize<'a> + std::fmt::Debug,
     {
         let unverified_token =
             UnverifiedToken::<P>::validate(token_string, self.check_expiration, &self.client_id)?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,8 @@ pub enum Error {
     RetrieveKeyFailure,
     UnsupportedAlgorithm(Algorithm),
     Expired,
+    #[cfg(feature = "rust-ssl")]
+    Rsa(rsa::errors::Error),
 }
 
 impl From<DecodeError> for Error {
@@ -21,8 +23,16 @@ impl From<serde_json::Error> for Error {
     }
 }
 
+#[cfg(feature = "native-ssl")]
 impl From<openssl::error::ErrorStack> for Error {
     fn from(_: openssl::error::ErrorStack) -> Self {
         Error::InvalidToken
+    }
+}
+
+#[cfg(feature = "rust-ssl")]
+impl From<rsa::errors::Error> for Error {
+    fn from(e: rsa::errors::Error) -> Self {
+        Error::Rsa(e)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,7 @@ pub enum InvalidError {
     #[cfg(feature = "native-ssl")]
     OpenSSL(String),
     #[cfg(feature = "rust-ssl")]
-    Rsa(rsa::errors::Error),
+    Crypto,
     TokenFormat(String),
     InvalidClaims(String),
     InvalidKeyId,
@@ -41,8 +41,9 @@ impl From<openssl::error::ErrorStack> for Error {
 }
 
 #[cfg(feature = "rust-ssl")]
-impl From<rsa::errors::Error> for Error {
-    fn from(e: rsa::errors::Error) -> Self {
-        Error::InvalidToken(InvalidError::Rsa(e))
+impl From<ring::error::Unspecified> for Error {
+    fn from(_: ring::error::Unspecified) -> Self {
+        // https://docs.rs/ring/0.17.8/ring/error/struct.Unspecified.html
+        Error::InvalidToken(InvalidError::Crypto)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,38 +1,48 @@
 use crate::algorithm::Algorithm;
-use base64::DecodeError;
+
+#[derive(Debug, PartialEq)]
+pub enum InvalidError {
+    Base64(base64::DecodeError),
+    Json(String),
+    #[cfg(feature = "native-ssl")]
+    OpenSSL(String),
+    #[cfg(feature = "rust-ssl")]
+    Rsa(rsa::errors::Error),
+    TokenFormat(String),
+    InvalidClaims(String),
+    InvalidKeyId,
+}
 
 #[derive(Debug, PartialEq)]
 pub enum Error {
-    InvalidToken,
+    InvalidToken(InvalidError),
     RetrieveKeyFailure,
     UnsupportedAlgorithm(Algorithm),
     Expired,
-    #[cfg(feature = "rust-ssl")]
-    Rsa(rsa::errors::Error),
 }
 
-impl From<DecodeError> for Error {
-    fn from(_: DecodeError) -> Self {
-        Error::InvalidToken
+impl From<base64::DecodeError> for Error {
+    fn from(e: base64::DecodeError) -> Self {
+        Error::InvalidToken(InvalidError::Base64(e))
     }
 }
 
 impl From<serde_json::Error> for Error {
-    fn from(_: serde_json::Error) -> Self {
-        Error::InvalidToken
+    fn from(e: serde_json::Error) -> Self {
+        Error::InvalidToken(InvalidError::Json(e.to_string()))
     }
 }
 
 #[cfg(feature = "native-ssl")]
 impl From<openssl::error::ErrorStack> for Error {
-    fn from(_: openssl::error::ErrorStack) -> Self {
-        Error::InvalidToken
+    fn from(e: openssl::error::ErrorStack) -> Self {
+        Error::InvalidToken(InvalidError::OpenSSL(e.to_string()))
     }
 }
 
 #[cfg(feature = "rust-ssl")]
 impl From<rsa::errors::Error> for Error {
     fn from(e: rsa::errors::Error) -> Self {
-        Error::Rsa(e)
+        Error::InvalidToken(InvalidError::Rsa(e))
     }
 }

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -1,11 +1,6 @@
 use crate::algorithm::Algorithm;
 use crate::base64_decode;
 use crate::error::Error;
-use openssl::bn::BigNum;
-use openssl::hash::MessageDigest;
-use openssl::pkey::PKey;
-use openssl::rsa::Rsa;
-use openssl::sign::Verifier;
 use serde_derive::Deserialize;
 
 #[derive(Deserialize, Clone)]
@@ -37,12 +32,31 @@ impl JsonWebKey {
     pub fn verify(&self, body: &[u8], signature: &[u8]) -> Result<(), Error> {
         match self.algorithm {
             Algorithm::RS256 => {
-                let n = BigNum::from_slice(&base64_decode(&self.n)?)?;
-                let e = BigNum::from_slice(&base64_decode(&self.e)?)?;
-                let key = PKey::from_rsa(Rsa::from_public_components(n, e)?)?;
-                let mut verifier = Verifier::new(MessageDigest::sha256(), &key)?;
-                verifier.update(body)?;
-                verifier.verify(signature)?;
+                // https://docs.rs/rsa/0.9.6/src/rsa/pkcs1v15.rs.html#561
+                // https://en.wikipedia.org/wiki/PKCS_1#Schemes
+                #[cfg(feature = "native-ssl")]
+                {
+                    use openssl::{
+                        bn::BigNum, hash::MessageDigest, pkey::PKey, rsa::Rsa, sign::Verifier,
+                    };
+                    let n = BigNum::from_slice(&base64_decode(&self.n)?)?;
+                    let e = BigNum::from_slice(&base64_decode(&self.e)?)?;
+                    let key = PKey::from_rsa(Rsa::from_public_components(n, e)?)?;
+                    let mut verifier = Verifier::new(MessageDigest::sha256(), &key)?;
+                    verifier.update(body)?;
+                    verifier.verify(signature)?;
+                }
+                #[cfg(feature = "rust-ssl")]
+                {
+                    use rsa::{pkcs1v15::Pkcs1v15Sign, BigUint, RsaPublicKey};
+                    use sha2::{Digest, Sha256};
+                    let n = BigUint::from_bytes_be(&base64_decode(&self.n)?.as_ref());
+                    let e = BigUint::from_bytes_be(&base64_decode(&self.e)?.as_ref());
+                    let key = RsaPublicKey::new(n, e).map_err(Error::from)?;
+                    let digest = Sha256::digest(body).to_vec();
+                    key.verify(Pkcs1v15Sign::new::<Sha256>(), &digest, signature)
+                        .map_err(Error::from)?;
+                }
                 Ok(())
             }
             _ => Err(Error::UnsupportedAlgorithm(self.algorithm)),

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -3,7 +3,7 @@ use crate::base64_decode;
 use crate::error::Error;
 use serde_derive::Deserialize;
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Debug)]
 pub struct JsonWebKeySet {
     keys: Vec<JsonWebKey>,
 }
@@ -14,7 +14,7 @@ impl JsonWebKeySet {
     }
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Debug)]
 pub struct JsonWebKey {
     #[serde(rename = "alg")]
     algorithm: Algorithm,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@ mod token;
 mod unverified_token;
 
 pub use crate::client::Client;
+#[cfg(feature = "async")]
+pub use crate::client::TokioClient;
 pub use crate::token::{IdPayload, RequiredClaims, Token};
 pub use error::Error;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,5 +17,6 @@ pub use crate::token::{IdPayload, RequiredClaims, Token};
 pub use error::Error;
 
 fn base64_decode(input: &str) -> Result<Vec<u8>, base64::DecodeError> {
-    base64::decode_config(&input, base64::URL_SAFE)
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+    URL_SAFE_NO_PAD.decode(&input)
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -16,29 +16,34 @@ use futures::future::join_all;
 #[cfg(feature = "async")]
 use async_trait::async_trait;
 
-const TOKEN: &'static str = "eyJhbGciOiJSUzI1NiIsImtpZCI6ImE3NDhlOWY3NjcxNTlmNjY3YTAyMjMzMThkZTBiMjMyOWU1NDQzNjIifQ.eyJhenAiOiIzNzc3MjExNzQwOC1xanFvOWhjYTUxM3BkY3VudW10N2drMDhpaTZ0ZThpcy5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbSIsImF1ZCI6IjM3NzcyMTE3NDA4LXFqcW85aGNhNTEzcGRjdW51bXQ3Z2swOGlpNnRlOGlzLmFwcHMuZ29vZ2xldXNlcmNvbnRlbnQuY29tIiwic3ViIjoiMTA3MDY3MzYxNTAzOTU0NDc0NDg4IiwiZW1haWwiOiJmdWNoc25qQGdtYWlsLmNvbSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJhdF9oYXNoIjoiaTBOWk5kYWp3UklJbDJvUk9zUUptUSIsImV4cCI6MTUyNjQ5MjUzMywiaXNzIjoiYWNjb3VudHMuZ29vZ2xlLmNvbSIsImp0aSI6IjNmMjc1YjRiY2JmZDU0Y2IxNjZmMzcxNWQ1NTBkMWNmMmUxYThiZGEiLCJpYXQiOjE1MjY0ODg5MzMsIm5hbWUiOiJOYXRoYW4gRm94IiwicGljdHVyZSI6Imh0dHBzOi8vbGg1Lmdvb2dsZXVzZXJjb250ZW50LmNvbS8tbEJSLWE3Z2gwdFkvQUFBQUFBQUFBQUkvQUFBQUFBQUFFUk0vNDFHUk43cDNNVzQvczk2LWMvcGhvdG8uanBnIiwiZ2l2ZW5fbmFtZSI6Ik5hdGhhbiIsImZhbWlseV9uYW1lIjoiRm94IiwibG9jYWxlIjoiZW4ifQ.pOoIMLZgZIFP-fgQirCRRK31ap_CO7WZDeHge-U5GoAvF0VdkoSDSL-1-8d93qKb8IWzi2iS2MgaLekcX8eELM5x39Th1sBwjQGjYr5AXmqE53WDQiqvKzrz-BZ3ay0uSAMllxWfFi62BkSP3m1HJNWyUWrUf6GyI-Vy024dtrX9Qq_BOznJWbQVhHf5aA7x5AAoLHZ_PmzxbUlDQ7Go6FD7sgkoksZI4Cp77HZJMXXGVOrvvXJkpctTcuBZ2P-2filLmb29JIm0e4McOjeHQTV7XNGdzTZoyeSZcU5xTVFQK89e-SIPHKyaL7TAr_faBbTGzVryYfa2VFyKi7Z9gA";
+const TOKEN: &'static str = "eyJhbGciOiJSUzI1NiIsImtpZCI6IjA5YmNmODAyOGUwNjUzN2Q0ZDNhZTRkODRmNWM1YmFiY2YyYzBmMGEiLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJhenAiOiIzNDk4Nzk2NDE2OTEtOXZnN2JnYnVuNjJkNGE2MnZwc2ZzMjRvZ3VndWFuazYuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJhdWQiOiIzNDk4Nzk2NDE2OTEtOXZnN2JnYnVuNjJkNGE2MnZwc2ZzMjRvZ3VndWFuazYuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWIiOiIxMDU5MDc5MDAwMDgxNzA4NzE1ODYiLCJlbWFpbCI6ImRhbi5qYW1lcy5iYXVtYW5uQGdtYWlsLmNvbSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJuYmYiOjE3MTA5NDcwOTUsIm5hbWUiOiJEYW4gQmF1bWFubiIsInBpY3R1cmUiOiJodHRwczovL2xoMy5nb29nbGV1c2VyY29udGVudC5jb20vYS9BQ2c4b2NKLXBGVHZTQkg1QlZISUxWZUVyQ0lpN1BYLUV6Q3NydzlMM05SX0xfRnA9czk2LWMiLCJnaXZlbl9uYW1lIjoiRGFuIiwiZmFtaWx5X25hbWUiOiJCYXVtYW5uIiwiaWF0IjoxNzEwOTQ3Mzk1LCJleHAiOjE3MTA5NTA5OTUsImp0aSI6ImRlNjg1MTk5ZTIxZDE5YjNlY2MyMTFlMDZjNGQ4NzRiNWFlMDhiMWUifQ.YdFwUBPlZExRZBlhZgaO9szNlm1Ffe3TNt8MauK7p30qikFo_EN6eKneVWS_TnpO1XtJoeeDsRDvewUoF0eQrN_G-eeVHl7Gsg5i6vgMYqNxObpwHh4oQaUNnUhTykNSjLuShB3FuBbq0NF6W6kC2UHwYqWmK360HpQjKF244zH2H0maLP5m1JIXdDSZb5KFSrXxGIIJpq2TCpz0JxdnPh9R4CzM_GgWnzwELO_nw3yyWYwQ1PCTyHg-RG6Xs-a8ZCPtLkgdeapqbapTnpBRqkIzbC97yw6WK7So1mQ3fNBTwLCygqfHcgJa_Snlgdl43pcVpbrFKFh8NTP7iW_N-Q";
 const JWKS: &'static str = r#"{
- "keys": [
-  {
-   "kty": "RSA",
-   "alg": "RS256",
-   "use": "sig",
-   "kid": "3f3ef9c7803cd0b8d75247ee0d31fdd5c2cf3812",
-   "n": "xM3ZHCgrJLe8y0rBZUWHOS1pCpJ2PjM_gw0WI9D0rljoZ7zWQpEC5UwpWaJqqDKxokt-kKP9GYXILqEsZrQ86qXvRZDPrP39RUjMl3Yl0hE4PlTx3aXuSE8SYqy506yduKjHw3seQHBiqSkVdLXSXqsEKUUrtFEgUxwL5L0yU4N3uJcAWK-oka8RxQSFJEilX5UOH-Qmz4UEeIr7Ma8cdsjibUc6xC9SRJtblmAdDDA_-1aMAJuYH8tGYnpTftwKbaaD0btq0LIzrsFnLu2--jaBul4u0k0jukolnUP0XSqE6NEc0iHTCdbKHZN6LrKVZoUqncTAS7Qa6TbgN1-lHw",
-   "e": "AQAB"
-  },
-  {
-   "kty": "RSA",
-   "alg": "RS256",
-   "use": "sig",
-   "kid": "a748e9f767159f667a0223318de0b2329e544362",
-   "n": "tuhr2NvyeXM215R3uvFHL040vM_jQvynwALBRCO0GPy4TxicZmmIEr3nxRsv7c2KNTQUltaiImSocdUwCczQYtCokb9TIx225hqoD-3Mr6dmqkicMcdjqVgjShRzgcHX7c1ipi9r7YvePdOyQutr-SrT9qHFbC5B5CGrY5J3VsEq6wNVeFwto9utMbn7YmENMJp5ws3O3p7YkSrRAxdhzVefciUWD3E6PZrDlcNBUVjKX1lTWfpcfKAUVqUT0Kf2_A1QCqMr1Sjsj8PGeAMtslsK1N59QhwCAarNaEW1H02iFqSalJpgSlw-wN6XMyc1wnIBpstJrjnFwvN0jTe34w",
-   "e": "AQAB"
-  }
- ]
+  "keys": [
+    {
+      "use": "sig",
+      "e": "AQAB",
+      "n": "vdtZ3cfuh44JlWkJRu-3yddVp58zxSHwsWiW_jpaXgpebo0an7qY2IEs3D7kC186Bwi0T7Km9mUcDbxod89IbtZuQQuhxlgaXB-qX9GokNLdqg69rUaealXGrCdKOQ-rOBlNNGn3M4KywEC98KyQAKXe7prs7yGqI_434rrULaE7ZFmLAzsYNoZ_8l53SGDiRaUrZkhxXOEhlv1nolgYGIH2lkhEZ5BlU53BfzwjO-bLeMwxJIZxSIOy8EBIMLP7eVu6AIkAr9MaDPJqeF7n7Cn8yv_qmy51bV-INRS-HKRVriSoUxhQQTbvDYYvJzHGYu_ciJ4oRYKkDEwxXztUew",
+      "alg": "RS256",
+      "kty": "RSA",
+      "kid": "09bcf8028e06537d4d3ae4d84f5c5babcf2c0f0a"
+    },
+    {
+      "n": "y48N6JB-AKq1-Rv4SkwBADU-hp4zXHU-NcCUwxD-aS9vr4EoT9qrjoJ-YmkaEpq9Bmu1yXZZK_h_9QS3xEsO8Rc_WSvIQCJtIaDQz8hxk4lUjUQjMB4Zf9vdTmf8KdktI9tCYCbuSbLC6TegjDM9kbl9CNs3m9wSVeO_5JXJQC0Jr-Oj7Gz9stXm0Co3f7RCxrD08kLelXaAglrd5TeGjZMyViC4cw1gPaj0Cj6knDn8UlzR_WuBpzs_ies5BrbzX-yht0WfnhXpdpiGNMbpKQD04MmPdMCYq8ENF7q5_Ok7dPsVj1vHA6vFGnf7qE3smD157szsnzn0NeXIbRMnuQ",
+      "kty": "RSA",
+      "use": "sig",
+      "kid": "adf5e710edfebecbefa9a61495654d03c0b8edf8",
+      "e": "AQAB",
+      "alg": "RS256"
+    }
+  ]
 }"#;
 const AUDIENCE: &'static str =
-    "37772117408-qjqo9hca513pdcunumt7gk08ii6te8is.apps.googleusercontent.com";
+    "349879641691-9vg7bgbun62d4a62vpsfs24oguguank6.apps.googleusercontent.com";
+const EMAIL: &'static str = "dan.james.baumann@gmail.com";
+const KIDS: [&str; 2] = [
+    "09bcf8028e06537d4d3ae4d84f5c5babcf2c0f0a",
+    "a748e9f767159f667a0223318de0b2329e544362",
+];
 
 #[derive(Default)]
 struct TestKeyProvider {
@@ -67,21 +72,17 @@ impl AsyncKeyProvider for TestKeyProvider {
 #[cfg(feature = "blocking")]
 #[test]
 pub fn decode_keys() {
-    TestKeyProvider::default()
-        .get_key("3f3ef9c7803cd0b8d75247ee0d31fdd5c2cf3812")
-        .unwrap();
-    TestKeyProvider::default()
-        .get_key("a748e9f767159f667a0223318de0b2329e544362")
-        .unwrap();
+    for kid in KIDS.iter() {
+        TestKeyProvider::default().get_key(kid).unwrap();
+    }
 }
 
 #[cfg(feature = "blocking")]
 #[test]
 pub fn test_client() {
-    let client =
-        Client::builder("37772117408-qjqo9hca513pdcunumt7gk08ii6te8is.apps.googleusercontent.com")
-            .custom_key_provider(TestKeyProvider::default())
-            .build();
+    let client = Client::builder(AUDIENCE)
+        .custom_key_provider(TestKeyProvider::default())
+        .build();
     assert_eq!(client.verify_token(TOKEN).map(|_| ()), Err(Error::Expired));
 }
 
@@ -92,7 +93,12 @@ pub fn test_client_invalid_client_id() {
         .custom_key_provider(TestKeyProvider::default())
         .build();
     let result = client.verify_token(TOKEN).map(|_| ());
-    assert_eq!(result, Err(Error::InvalidToken))
+    assert_eq!(
+        result,
+        Err(Error::InvalidToken(error::InvalidError::InvalidClaims(
+            "aud".to_string()
+        )))
+    )
 }
 
 #[cfg(feature = "blocking")]
@@ -107,30 +113,23 @@ pub fn test_id_token() {
         .expect("id token should be valid");
     assert_eq!(id_token.get_claims().get_audience(), AUDIENCE);
     assert_eq!(id_token.get_payload().get_domain(), None);
-    assert_eq!(id_token.get_payload().get_email(), "fuchsnj@gmail.com");
+    assert_eq!(id_token.get_payload().get_email(), EMAIL);
 }
 
 #[cfg(feature = "async")]
 #[tokio::test]
 async fn decode_keys_async() {
-    TestKeyProvider::default()
-        .get_key_async("3f3ef9c7803cd0b8d75247ee0d31fdd5c2cf3812")
-        .await
-        .unwrap();
-    TestKeyProvider::default()
-        .get_key_async("a748e9f767159f667a0223318de0b2329e544362")
-        .await
-        .unwrap();
+    for kid in KIDS.iter() {
+        TestKeyProvider::default().get_key_async(kid).await.unwrap();
+    }
 }
 
 #[cfg(feature = "async")]
 #[tokio::test]
 async fn test_client_async() {
-    let client = TokioClient::builder(
-        "37772117408-qjqo9hca513pdcunumt7gk08ii6te8is.apps.googleusercontent.com",
-    )
-    .custom_key_provider(TestKeyProvider::default())
-    .build();
+    let client = TokioClient::builder(AUDIENCE)
+        .custom_key_provider(TestKeyProvider::default())
+        .build();
     assert_eq!(
         client.verify_token_async(TOKEN).await.map(|_| ()),
         Err(Error::Expired)
@@ -144,7 +143,12 @@ async fn test_client_invalid_client_id_async() {
         .custom_key_provider(TestKeyProvider::default())
         .build();
     let result = client.verify_token_async(TOKEN).await.map(|_| ());
-    assert_eq!(result, Err(Error::InvalidToken))
+    assert_eq!(
+        result,
+        Err(Error::InvalidToken(error::InvalidError::InvalidClaims(
+            "aud".to_string()
+        )))
+    );
 }
 
 #[cfg(feature = "async")]
@@ -160,7 +164,7 @@ async fn test_id_token_async() {
         .expect("id token should be valid");
     assert_eq!(id_token.get_claims().get_audience(), AUDIENCE);
     assert_eq!(id_token.get_payload().get_domain(), None);
-    assert_eq!(id_token.get_payload().get_email(), "fuchsnj@gmail.com");
+    assert_eq!(id_token.get_payload().get_email(), EMAIL);
 }
 
 #[cfg(feature = "async")]
@@ -175,5 +179,11 @@ async fn test_deadlock_prevention() {
 #[cfg(feature = "async")]
 async fn verify_token_async(client: &TokioClient) {
     let result = client.verify_token_async(TOKEN).await;
-    assert_eq!(result, Err(Error::InvalidToken));
+    assert!(matches!(
+        result,
+        Err(Error::InvalidToken(error::InvalidError::Json(_)))
+    ));
+    // verify_token_async expects an empty payload, which serde_json tries to parse as '{}'
+    // therefore the token is considered invalid due to failed json parsing:
+    // invalid type: map, expected unit at line 1 column 0
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,4 +1,8 @@
+use std::sync::Arc;
+
 use super::*;
+#[cfg(feature = "async")]
+use crate::client::TokioClient;
 use crate::error::Error;
 use crate::jwk::JsonWebKey;
 use crate::jwk::JsonWebKeySet;
@@ -6,6 +10,8 @@ use crate::jwk::JsonWebKeySet;
 use crate::key_provider::AsyncKeyProvider;
 #[cfg(feature = "blocking")]
 use crate::key_provider::KeyProvider;
+#[cfg(feature = "async")]
+use futures::future::join_all;
 
 #[cfg(feature = "async")]
 use async_trait::async_trait;
@@ -34,12 +40,16 @@ const JWKS: &'static str = r#"{
 const AUDIENCE: &'static str =
     "37772117408-qjqo9hca513pdcunumt7gk08ii6te8is.apps.googleusercontent.com";
 
-struct TestKeyProvider;
+#[derive(Default)]
+struct TestKeyProvider {
+    call_count: Arc<std::sync::RwLock<u8>>,
+}
 
 #[cfg(feature = "blocking")]
 impl KeyProvider for TestKeyProvider {
     fn get_key(&mut self, key_id: &str) -> Result<Option<JsonWebKey>, ()> {
         let set: JsonWebKeySet = serde_json::from_str(JWKS).unwrap();
+        *self.call_count.write().unwrap() += 1;
         Ok(set.get_key(key_id))
     }
 }
@@ -49,6 +59,7 @@ impl KeyProvider for TestKeyProvider {
 impl AsyncKeyProvider for TestKeyProvider {
     async fn get_key_async(&mut self, key_id: &str) -> Result<Option<JsonWebKey>, ()> {
         let set: JsonWebKeySet = serde_json::from_str(JWKS).unwrap();
+        *self.call_count.write().unwrap() += 1;
         Ok(set.get_key(key_id))
     }
 }
@@ -56,10 +67,10 @@ impl AsyncKeyProvider for TestKeyProvider {
 #[cfg(feature = "blocking")]
 #[test]
 pub fn decode_keys() {
-    TestKeyProvider
+    TestKeyProvider::default()
         .get_key("3f3ef9c7803cd0b8d75247ee0d31fdd5c2cf3812")
         .unwrap();
-    TestKeyProvider
+    TestKeyProvider::default()
         .get_key("a748e9f767159f667a0223318de0b2329e544362")
         .unwrap();
 }
@@ -69,7 +80,7 @@ pub fn decode_keys() {
 pub fn test_client() {
     let client =
         Client::builder("37772117408-qjqo9hca513pdcunumt7gk08ii6te8is.apps.googleusercontent.com")
-            .custom_key_provider(TestKeyProvider)
+            .custom_key_provider(TestKeyProvider::default())
             .build();
     assert_eq!(client.verify_token(TOKEN).map(|_| ()), Err(Error::Expired));
 }
@@ -78,7 +89,7 @@ pub fn test_client() {
 #[test]
 pub fn test_client_invalid_client_id() {
     let client = Client::builder("invalid client id")
-        .custom_key_provider(TestKeyProvider)
+        .custom_key_provider(TestKeyProvider::default())
         .build();
     let result = client.verify_token(TOKEN).map(|_| ());
     assert_eq!(result, Err(Error::InvalidToken))
@@ -88,7 +99,7 @@ pub fn test_client_invalid_client_id() {
 #[test]
 pub fn test_id_token() {
     let client = Client::builder(AUDIENCE)
-        .custom_key_provider(TestKeyProvider)
+        .custom_key_provider(TestKeyProvider::default())
         .unsafe_ignore_expiration()
         .build();
     let id_token = client
@@ -102,11 +113,11 @@ pub fn test_id_token() {
 #[cfg(feature = "async")]
 #[tokio::test]
 async fn decode_keys_async() {
-    TestKeyProvider
+    TestKeyProvider::default()
         .get_key_async("3f3ef9c7803cd0b8d75247ee0d31fdd5c2cf3812")
         .await
         .unwrap();
-    TestKeyProvider
+    TestKeyProvider::default()
         .get_key_async("a748e9f767159f667a0223318de0b2329e544362")
         .await
         .unwrap();
@@ -115,10 +126,11 @@ async fn decode_keys_async() {
 #[cfg(feature = "async")]
 #[tokio::test]
 async fn test_client_async() {
-    let client =
-        Client::builder("37772117408-qjqo9hca513pdcunumt7gk08ii6te8is.apps.googleusercontent.com")
-            .custom_key_provider(TestKeyProvider)
-            .build();
+    let client = TokioClient::builder(
+        "37772117408-qjqo9hca513pdcunumt7gk08ii6te8is.apps.googleusercontent.com",
+    )
+    .custom_key_provider(TestKeyProvider::default())
+    .build();
     assert_eq!(
         client.verify_token_async(TOKEN).await.map(|_| ()),
         Err(Error::Expired)
@@ -128,8 +140,8 @@ async fn test_client_async() {
 #[cfg(feature = "async")]
 #[tokio::test]
 async fn test_client_invalid_client_id_async() {
-    let client = Client::builder("invalid client id")
-        .custom_key_provider(TestKeyProvider)
+    let client = TokioClient::builder("invalid client id")
+        .custom_key_provider(TestKeyProvider::default())
         .build();
     let result = client.verify_token_async(TOKEN).await.map(|_| ());
     assert_eq!(result, Err(Error::InvalidToken))
@@ -138,8 +150,8 @@ async fn test_client_invalid_client_id_async() {
 #[cfg(feature = "async")]
 #[tokio::test]
 async fn test_id_token_async() {
-    let client = Client::builder(AUDIENCE)
-        .custom_key_provider(TestKeyProvider)
+    let client = TokioClient::builder(AUDIENCE)
+        .custom_key_provider(TestKeyProvider::default())
         .unsafe_ignore_expiration()
         .build();
     let id_token = client
@@ -149,4 +161,19 @@ async fn test_id_token_async() {
     assert_eq!(id_token.get_claims().get_audience(), AUDIENCE);
     assert_eq!(id_token.get_payload().get_domain(), None);
     assert_eq!(id_token.get_payload().get_email(), "fuchsnj@gmail.com");
+}
+
+#[cfg(feature = "async")]
+#[tokio::test]
+async fn test_deadlock_prevention() {
+    let client = TokioClient::builder(AUDIENCE)
+        .unsafe_ignore_expiration()
+        .build();
+    join_all((0..10u8).map(|_| verify_token_async(&client))).await;
+}
+
+#[cfg(feature = "async")]
+async fn verify_token_async(client: &TokioClient) {
+    let result = client.verify_token_async(TOKEN).await;
+    assert_eq!(result, Err(Error::InvalidToken));
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -21,6 +21,7 @@ impl<P> Token<P> {
     }
 }
 
+// https://datatracker.ietf.org/doc/html/rfc7519#section-4.1
 #[derive(PartialEq, Deserialize, Debug, Clone)]
 pub struct RequiredClaims {
     #[serde(rename = "iss")]
@@ -32,14 +33,20 @@ pub struct RequiredClaims {
     #[serde(rename = "aud")]
     audience: String,
 
-    #[serde(rename = "azp")]
-    android_audience: String,
+    #[serde(rename = "exp")]
+    expires_at: u64,
+
+    #[serde(rename = "nbf")]
+    not_before: u64,
 
     #[serde(rename = "iat")]
     issued_at: u64,
 
-    #[serde(rename = "exp")]
-    expires_at: u64,
+    #[serde(rename = "jti")]
+    jwt_id: String,
+
+    #[serde(rename = "azp")]
+    android_audience: String,
 }
 
 impl RequiredClaims {
@@ -52,18 +59,25 @@ impl RequiredClaims {
     pub fn get_audience(&self) -> String {
         self.audience.clone()
     }
-    pub fn get_android_audience(&self) -> String {
-        self.android_audience.clone()
+    pub fn get_expires_at(&self) -> u64 {
+        self.expires_at
+    }
+    pub fn get_not_before(&self) -> u64 {
+        self.not_before
     }
     pub fn get_issued_at(&self) -> u64 {
         self.issued_at
     }
-    pub fn get_expires_at(&self) -> u64 {
-        self.expires_at
+    pub fn get_jwt_id(&self) -> String {
+        self.jwt_id.clone()
+    }
+    pub fn get_android_audience(&self) -> String {
+        self.android_audience.clone()
     }
 }
 
-#[derive(Deserialize, Clone)]
+// https://developers.google.com/identity/gsi/web/reference/html-reference#credential
+#[derive(Deserialize, Clone, Debug)]
 pub struct IdPayload {
     email: String,
     email_verified: bool,
@@ -71,7 +85,7 @@ pub struct IdPayload {
     picture: String,
     given_name: String,
     family_name: String,
-    locale: String,
+    locale: Option<String>,
     hd: Option<String>,
 }
 
@@ -94,7 +108,7 @@ impl IdPayload {
     pub fn get_family_name(&self) -> String {
         self.family_name.clone()
     }
-    pub fn get_locale(&self) -> String {
+    pub fn get_locale(&self) -> Option<String> {
         self.locale.clone()
     }
     pub fn get_domain(&self) -> Option<String> {

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,5 +1,6 @@
 use serde_derive::Deserialize;
 
+#[derive(Debug, PartialEq)]
 pub struct Token<P> {
     required_claims: RequiredClaims,
     payload: P,
@@ -20,7 +21,7 @@ impl<P> Token<P> {
     }
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(PartialEq, Deserialize, Debug, Clone)]
 pub struct RequiredClaims {
     #[serde(rename = "iss")]
     issuer: String,

--- a/src/unverified_token.rs
+++ b/src/unverified_token.rs
@@ -75,10 +75,10 @@ impl<P> UnverifiedToken<P> {
     #[cfg(feature = "async")]
     pub async fn verify_async<KP: AsyncKeyProvider>(
         self,
-        key_provider: &Arc<Mutex<KP>>,
+        key_provider: &Arc<tokio::sync::Mutex<KP>>,
     ) -> Result<Token<P>, Error> {
         let key_id = self.header.key_id.clone();
-        self.verify_with_key(key_provider.lock().unwrap().get_key_async(&key_id).await)
+        self.verify_with_key(key_provider.lock().await.get_key_async(&key_id).await)
     }
     fn verify_with_key(self, key: Result<Option<JsonWebKey>, ()>) -> Result<Token<P>, Error> {
         let key = match key {

--- a/src/unverified_token.rs
+++ b/src/unverified_token.rs
@@ -1,16 +1,18 @@
 use std::{
-    sync::{Arc, Mutex},
+    sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
 
 use serde::Deserialize;
 
+use crate::error::InvalidError::{InvalidClaims, InvalidKeyId, TokenFormat};
 #[cfg(feature = "async")]
 use crate::key_provider::AsyncKeyProvider;
 #[cfg(feature = "blocking")]
 use crate::key_provider::KeyProvider;
 use crate::{base64_decode, header::Header, jwk::JsonWebKey, Error, RequiredClaims, Token};
 
+#[derive(Debug)]
 pub struct UnverifiedToken<P> {
     header: Header,
     signed_body: String,
@@ -21,7 +23,7 @@ pub struct UnverifiedToken<P> {
 
 impl<P> UnverifiedToken<P>
 where
-    for<'a> P: Deserialize<'a>,
+    for<'a> P: Deserialize<'a> + std::fmt::Debug,
 {
     pub fn validate(
         token_string: &str,
@@ -29,9 +31,15 @@ where
         client_id: &str,
     ) -> Result<Self, Error> {
         let mut segments = token_string.split('.');
-        let encoded_header = segments.next().ok_or(Error::InvalidToken)?;
-        let encoded_payload = segments.next().ok_or(Error::InvalidToken)?;
-        let encoded_signature = segments.next().ok_or(Error::InvalidToken)?;
+        let encoded_header = segments
+            .next()
+            .ok_or(Error::InvalidToken(TokenFormat("header".to_string())))?;
+        let encoded_payload = segments
+            .next()
+            .ok_or(Error::InvalidToken(TokenFormat("payload".to_string())))?;
+        let encoded_signature = segments
+            .next()
+            .ok_or(Error::InvalidToken(TokenFormat("signature".to_string())))?;
 
         let header: Header = serde_json::from_slice(&base64_decode(&encoded_header)?)?;
         let signed_body = format!("{}.{}", encoded_header, encoded_payload);
@@ -39,11 +47,11 @@ where
         let payload = base64_decode(&encoded_payload)?;
         let claims: RequiredClaims = serde_json::from_slice(&payload)?;
         if claims.get_audience() != client_id {
-            return Err(Error::InvalidToken);
+            return Err(Error::InvalidToken(InvalidClaims("aud".to_string())));
         }
         let issuer = claims.get_issuer();
         if issuer != "https://accounts.google.com" && issuer != "accounts.google.com" {
-            return Err(Error::InvalidToken);
+            return Err(Error::InvalidToken(InvalidClaims("iss".to_string())));
         }
         let current_timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -53,7 +61,7 @@ where
             return Err(Error::Expired);
         }
         if claims.get_issued_at() > claims.get_expires_at() {
-            return Err(Error::InvalidToken);
+            return Err(Error::InvalidToken(InvalidClaims("iat > exp".to_string())));
         }
         let json_payload: P = serde_json::from_slice(&payload)?;
         Ok(Self {
@@ -68,7 +76,10 @@ where
 
 impl<P> UnverifiedToken<P> {
     #[cfg(feature = "blocking")]
-    pub fn verify<KP: KeyProvider>(self, key_provider: &Arc<Mutex<KP>>) -> Result<Token<P>, Error> {
+    pub fn verify<KP: KeyProvider>(
+        self,
+        key_provider: &Arc<std::sync::Mutex<KP>>,
+    ) -> Result<Token<P>, Error> {
         let key_id = self.header.key_id.clone();
         self.verify_with_key(key_provider.lock().unwrap().get_key(&key_id))
     }
@@ -83,7 +94,7 @@ impl<P> UnverifiedToken<P> {
     fn verify_with_key(self, key: Result<Option<JsonWebKey>, ()>) -> Result<Token<P>, Error> {
         let key = match key {
             Ok(Some(key)) => key,
-            Ok(None) => return Err(Error::InvalidToken),
+            Ok(None) => return Err(Error::InvalidToken(InvalidKeyId)),
             Err(_) => return Err(Error::RetrieveKeyFailure),
         };
         key.verify(self.signed_body.as_bytes(), &self.signature)?;


### PR DESCRIPTION
`std::sync::Mutex::lock` blocks the current thread if another one is holding it so will cause deadlocks when multiple calls to `lock` are made on the same thread inside a `tokio` runtime. Using `tokio::sync::Mutex` in a `TokioClient` fixes this deadlock as tested in test_deadlock_prevention. It seems as though each async runtime will have to be explicitly supported.