### PR TITLE
adding async_client, which uses tokio::sync::Mutex instead of std::sync::Mutex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,5 @@ serde_derive = "1.0.104"
 reqwest = {version="0.10.4"}
 headers = "0.3.1"
 
-[dev-dependencies]
-tokio = {version = "0.2", features = ["macros"]}
+# [dev-dependencies]
+tokio = {version = "0.2", features = ["macros", "sync"]}

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -1,0 +1,96 @@
+use crate::error::Error;
+#[cfg(feature = "async")]
+use crate::key_provider::AsyncKeyProvider;
+use crate::key_provider::GoogleKeyProvider;
+#[cfg(feature = "blocking")]
+use crate::key_provider::KeyProvider;
+use crate::token::IdPayload;
+use crate::token::Token;
+use crate::unverified_token::UnverifiedToken;
+use serde::Deserialize;
+
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+pub type AsyncClient = GenericClient<GoogleKeyProvider>;
+
+pub struct GenericClientBuilder<KP> {
+    client_id: String,
+    key_provider: Arc<Mutex<KP>>,
+    check_expiration: bool,
+}
+
+impl<KP: Default> GenericClientBuilder<KP> {
+    pub fn new(client_id: &str) -> GenericClientBuilder<KP> {
+        GenericClientBuilder::<KP> {
+            client_id: client_id.to_owned(),
+            key_provider: Arc::new(Mutex::new(KP::default())),
+            check_expiration: true,
+        }
+    }
+}
+
+impl<KP> GenericClientBuilder<KP> {
+    pub fn custom_key_provider<T>(self, provider: T) -> GenericClientBuilder<T> {
+        GenericClientBuilder {
+            client_id: self.client_id,
+            key_provider: Arc::new(Mutex::new(provider)),
+            check_expiration: self.check_expiration,
+        }
+    }
+    pub fn unsafe_ignore_expiration(mut self) -> Self {
+        self.check_expiration = false;
+        self
+    }
+    pub fn build(self) -> GenericClient<KP> {
+        GenericClient {
+            client_id: self.client_id,
+            key_provider: self.key_provider,
+            check_expiration: self.check_expiration,
+        }
+    }
+}
+
+pub struct GenericClient<T> {
+    client_id: String,
+    key_provider: Arc<Mutex<T>>,
+    check_expiration: bool,
+}
+
+impl<KP: Default> GenericClient<KP> {
+    pub fn builder(client_id: &str) -> GenericClientBuilder<KP> {
+        GenericClientBuilder::<KP>::new(client_id)
+    }
+    pub fn new(client_id: &str) -> GenericClient<KP> {
+        GenericClientBuilder::new(client_id).build()
+    }
+}
+
+#[cfg(feature = "async")]
+impl<KP: AsyncKeyProvider> GenericClient<KP> {
+    pub async fn verify_token_with_payload_async<P>(
+        &self,
+        token_string: &str,
+    ) -> Result<Token<P>, Error>
+    where
+        for<'a> P: Deserialize<'a>,
+    {
+        let unverified_token =
+            UnverifiedToken::<P>::validate(token_string, self.check_expiration, &self.client_id)?;
+        unverified_token
+            .verify_async_mutex(&self.key_provider)
+            .await
+    }
+
+    pub async fn verify_token_async(&self, token_string: &str) -> Result<Token<()>, Error> {
+        self.verify_token_with_payload_async::<()>(token_string)
+            .await
+    }
+
+    pub async fn verify_id_token_async(
+        &self,
+        token_string: &str,
+    ) -> Result<Token<IdPayload>, Error> {
+        self.verify_token_with_payload_async(token_string).await
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 mod test;
 
 mod algorithm;
+mod async_client;
 mod client;
 mod error;
 mod header;
@@ -10,6 +11,7 @@ mod key_provider;
 mod token;
 mod unverified_token;
 
+pub use crate::async_client::AsyncClient;
 pub use crate::client::Client;
 pub use crate::token::{IdPayload, RequiredClaims, Token};
 pub use error::Error;


### PR DESCRIPTION
Hello! I am not sure if you would like to merge these changes. But, adding it anyways for your review.

Technical details as to why this change was necessary? It applies more for actix-web framework
I am using this library within Actix-web to verify google token for every incoming request. This verification is done within "FromRequest" trait implemented for a custom struct, which has a closure to return sqlx (async) data. It kept complaining about "Mutex guard can't be sent across thread. Send is not implemented.......". Upon researching this topic further led me to tokio::sync::Mutex. Essentially, this change simply replaces standard Mutex with tokio::sync::Mutex within async_client, adds a new function "verify_async_mutex" in unverified_token.rs which uses tokion mutex. Existing code remains as is.

Example usage on one would use this in Actix-web:

```
use google_jwt_verify;

impl FromRequest for AuthenticatedUser {
    type Error = AppError;
    // type Future = Ready<Result<Self, Self::Error>>;
    type Future = BoxFuture<'static, Result<Self, Self::Error>>;

    type Config = ();

    fn from_request(req: &HttpRequest, payload: &mut dev::Payload) -> Self::Future {
         let db_pool = req.app_data::<Data<PgPool>>().unwrap().clone();
         let bearer_result = BearerAuth::from_request(req, payload).into_inner();
         match (bearer_result) {
              Ok(bearer) => {
                   let future = async move {
                    let g_data =
                        google_jwt_verify::AsyncClient::new(&client_id)
                            .verify_id_token_async(bearer.token())
                            .await;
                    match g_data {
                        Ok(token) => {
                            let user_id = token.get_claims().get_subject();
                            let user = User::find_user_id(&user_id, &db_pool).await?.ok_or_else(
                                || {
                                    debug!("User not found");
                                    AppError::NOT_AUTHORIZED
                                },
                            )?;

                            Ok(AuthenticatedUser { user })
                        }
                        Err(e) => {
                            debug!("Error while decoding Google token: {:?}", e);
                            Err(AppError::NOT_AUTHORIZED.into())
                        }
                    }
                };

                Box::pin(future)
         }
```