### PR TITLE
made email and email_verified optional in IdPayload

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -68,7 +68,7 @@ pub fn decode_keys() {
 #[test]
 pub fn test_client() {
     let client =
-        Client::builder("37772117408-qjqo9hca513pdcunumt7gk08ii6te8is.apps.googleusercontent.com")
+        Client::builder(AUDIENCE)
             .custom_key_provider(TestKeyProvider)
             .build();
     assert_eq!(client.verify_token(TOKEN).map(|_| ()), Err(Error::Expired));
@@ -96,7 +96,9 @@ pub fn test_id_token() {
         .expect("id token should be valid");
     assert_eq!(id_token.get_claims().get_audience(), AUDIENCE);
     assert_eq!(id_token.get_payload().get_domain(), None);
-    assert_eq!(id_token.get_payload().get_email(), "fuchsnj@gmail.com");
+    if let Some(email) = id_token.get_payload().get_email() {
+        assert_eq!(email, "fuchsnj@gmail.com");
+    }
 }
 
 #[cfg(feature = "async")]
@@ -116,7 +118,7 @@ async fn decode_keys_async() {
 #[tokio::test]
 async fn test_client_async() {
     let client =
-        Client::builder("37772117408-qjqo9hca513pdcunumt7gk08ii6te8is.apps.googleusercontent.com")
+        Client::builder(AUDIENCE)
             .custom_key_provider(TestKeyProvider)
             .build();
     assert_eq!(
@@ -148,5 +150,7 @@ async fn test_id_token_async() {
         .expect("id token should be valid");
     assert_eq!(id_token.get_claims().get_audience(), AUDIENCE);
     assert_eq!(id_token.get_payload().get_domain(), None);
-    assert_eq!(id_token.get_payload().get_email(), "fuchsnj@gmail.com");
+    if let Some(email) = id_token.get_payload().get_email() {
+        assert_eq!(email, "fuchsnj@gmail.com");
+    }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -64,8 +64,8 @@ impl RequiredClaims {
 
 #[derive(Deserialize, Clone)]
 pub struct IdPayload {
-    email: String,
-    email_verified: bool,
+    email: Option<String>,
+    email_verified: Option<bool>,
     name: String,
     picture: String,
     given_name: String,
@@ -75,10 +75,10 @@ pub struct IdPayload {
 }
 
 impl IdPayload {
-    pub fn get_email(&self) -> String {
+    pub fn get_email(&self) -> Option<String> {
         self.email.clone()
     }
-    pub fn is_email_verified(&self) -> bool {
+    pub fn is_email_verified(&self) -> Option<bool> {
         self.email_verified
     }
     pub fn get_name(&self) -> String {


### PR DESCRIPTION
Hi, according to [Google's OpenID Connect documentation](https://developers.google.com/identity/protocols/oauth2/openid-connect#obtaininguserprofileinformation), user's email address is optional and not part of the `openid profile`.  To have user's email included requires specifying an additional scope value.

I have modified both `IdProfile.email` and `IdProfile.email_verified` to be of `Option` types. This allows `idToken`s not containing email addresses to be verified as valid. Otherwise `Client.verify_id_token()` and `Client.verify_id_token_async()` would return `InvalidToken`.