### PR TITLE
`locale` field of IdToken should be optional

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -96,7 +96,7 @@ pub fn test_id_token() {
         .expect("id token should be valid");
     assert_eq!(id_token.get_claims().get_audience(), AUDIENCE);
     assert_eq!(id_token.get_payload().get_domain(), None);
-    assert_eq!(id_token.get_payload().get_email(), "fuchsnj@gmail.com");
+    assert_eq!(id_token.get_payload().get_email(), Some("fuchsnj@gmail.com".to_string()));
 }
 
 #[cfg(feature = "async")]
@@ -148,5 +148,5 @@ async fn test_id_token_async() {
         .expect("id token should be valid");
     assert_eq!(id_token.get_claims().get_audience(), AUDIENCE);
     assert_eq!(id_token.get_payload().get_domain(), None);
-    assert_eq!(id_token.get_payload().get_email(), "fuchsnj@gmail.com");
+    assert_eq!(id_token.get_payload().get_email(), Some("fuchsnj@gmail.com".to_string()));
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -64,8 +64,8 @@ impl RequiredClaims {
 
 #[derive(Deserialize, Clone)]
 pub struct IdPayload {
-    email: String,
-    email_verified: bool,
+    email: Option<String>,
+    email_verified: Option<bool>,
     name: String,
     picture: String,
     given_name: String,
@@ -75,10 +75,10 @@ pub struct IdPayload {
 }
 
 impl IdPayload {
-    pub fn get_email(&self) -> String {
+    pub fn get_email(&self) -> Option<String> {
         self.email.clone()
     }
-    pub fn is_email_verified(&self) -> bool {
+    pub fn is_email_verified(&self) -> Option<bool> {
         self.email_verified
     }
     pub fn get_name(&self) -> String {

--- a/src/token.rs
+++ b/src/token.rs
@@ -70,7 +70,7 @@ pub struct IdPayload {
     picture: String,
     given_name: String,
     family_name: String,
-    locale: String,
+    locale: Option<String>,
     hd: Option<String>,
 }
 
@@ -93,7 +93,7 @@ impl IdPayload {
     pub fn get_family_name(&self) -> String {
         self.family_name.clone()
     }
-    pub fn get_locale(&self) -> String {
+    pub fn get_locale(&self) -> Option<String> {
         self.locale.clone()
     }
     pub fn get_domain(&self) -> Option<String> {


### PR DESCRIPTION
I've faced a error when tried to validate idToken. `locale` field was not present so I assume it should be optional. Sample from google:

{
   "iss":"https://accounts.google.com",
   "azp":"1097023013474-....apps.googleusercontent.com",
   "aud":"1097023013474-....apps.googleusercontent.com",
   "sub":"108107954005561105441",
   "email":"...@gmail.com",
   "email_verified":true,
   "at_hash":"Gq84QJdFQlWJWjVkEPBW2Q",
   "nonce":"WA47KnMlo23FVwGa1MjoOlMBDaaoBZ1yb7SnTP_sdDU",
   "name":"Rishat Zakirov",
   "picture":"https://lh3.googleusercontent.com/a/...=s96-c",
   "given_name":"Rishat",
   "family_name":"Zakirov",
   "iat":1768619920,
   "exp":1768623520
} 